### PR TITLE
Spec 1: one declared CWL substrate version, enforced at every emitting path

### DIFF
--- a/src/sophios/api/python/tool_builder.py
+++ b/src/sophios/api/python/tool_builder.py
@@ -63,6 +63,7 @@ from ._tool_builder_support import (
     ValidationResult,
     validate_cwl_document,
 )
+from ...lang.cwl import CWL_VERSION
 
 if TYPE_CHECKING:
     from .workflow import Step
@@ -76,7 +77,7 @@ class CommandLineTool:
     name: str
     inputs: Inputs
     outputs: Outputs
-    cwl_version: str = "v1.2"
+    cwl_version: str = CWL_VERSION
     label_text: str | None = None
     doc_text: str | list[str] | None = None
     _base_command: list[str] = field(default_factory=list)
@@ -100,7 +101,7 @@ class CommandLineTool:
         inputs: Inputs,
         outputs: Outputs,
         *,
-        cwl_version: str = "v1.2",
+        cwl_version: str = CWL_VERSION,
     ) -> None:
         self.name = name
         self.inputs = inputs

--- a/src/sophios/compiler.py
+++ b/src/sophios/compiler.py
@@ -17,6 +17,7 @@ from .wic_types import (CompilerInfo, CompilerOptions, EnvData, ExplicitEdgeCall
                         ExplicitEdgeDefs, GraphData, GraphReps, GraphSettings, Namespaces,
                         NodeData, RoseTree, Tool, Tools, WorkflowInputs, WorkflowInputsFile,
                         WorkflowOutputs, Yaml, YamlTagPaths, YamlTree, StepId)
+from .lang.cwl import CWL_VERSION
 
 # NOTE: This must be initialized in main.py and/or cwl_subinterpreter.py
 inference_rules: dict[str, str] = {}
@@ -198,7 +199,7 @@ def _prepare_compilation_state(yaml_tree_ast: YamlTree,
     # Add headers
     # Use 1.0 because cromwell only supports 1.0 and we are not using 1.1 / 1.2 features.
     # Eventually we will want to use 1.2 to support conditional workflows and 1.3 to support loops.
-    yaml_tree['cwlVersion'] = yaml_tree.get('cwlVersion', 'v1.2')
+    yaml_tree['cwlVersion'] = yaml_tree.get('cwlVersion', CWL_VERSION)
     yaml_tree['class'] = 'Workflow'
     namespaces_value = yaml_tree.get('$namespaces', {})
     if namespaces_value is None:

--- a/src/sophios/contrib/ict/ict_spec/tools/cwl_ict.py
+++ b/src/sophios/contrib/ict/ict_spec/tools/cwl_ict.py
@@ -6,6 +6,7 @@ from typing import Any, TYPE_CHECKING, cast
 from sophios.contrib.ict.ict_spec.hardware import HardwareRequirements
 from sophios.contrib.ict.ict_spec.io import IO
 from sophios.contrib.ict.ict_spec.ui import UIItem
+from sophios.lang.cwl import CWL_VERSION
 
 if TYPE_CHECKING:
     from sophios.contrib.ict.ict_spec.model import ICT
@@ -31,7 +32,7 @@ def clt_dict(ict_: "ICT", network_access: bool) -> dict[str, Any]:
 
     clt_: dict[str, Any] = {
         "class": "CommandLineTool",
-        "cwlVersion": "v1.2",
+        "cwlVersion": CWL_VERSION,
         "inputs": {
             # IO deliberately keeps _input_to_cwl/_output_to_cwl protected: they are
             # implementation details of the ICT<->CWL conversion that only this module needs.

--- a/src/sophios/lang/__init__.py
+++ b/src/sophios/lang/__init__.py
@@ -10,6 +10,7 @@ again reproduces the document it started from.
 
 See design_docs/core-refactor-design.md, Spec 1.
 """
+from .cwl import CWL_VERSION, CWL_VERSIONS, CwlVersion
 from .diagnostics import Code, Diagnostic, Diagnostics, Severity
 from .nodes import (
     Document,
@@ -38,6 +39,9 @@ from .schema import wic_schema
 from .spans import SourceSpan
 
 __all__ = [
+    'CWL_VERSION',
+    'CWL_VERSIONS',
+    'CwlVersion',
     'DESUGARED_KEYS',
     'INTERPRETED_STEP_KEYS',
     'TAG_RAW_CWL',

--- a/src/sophios/lang/cwl.py
+++ b/src/sophios/lang/cwl.py
@@ -1,0 +1,65 @@
+"""The CWL substrate the Sophios language compiles onto.
+
+The language reference pins Sophios to a specific CWL version and says the two
+move together, so the version belongs to the language definition rather than to
+whichever module happens to emit a document. Before this module there were six
+places that named a version, and two of them disagreed with the other four: a
+CommandLineTool generator still emitting `v1.0`, and a schema accepting any
+non-empty string at all.
+
+Import `CWL_VERSION` rather than writing a version literal. A test asserts that
+no emitting path in the tree carries its own (see `tests/core/test_cwl_version.py`),
+because the failure it prevents is silent: a document that declares the wrong
+version still looks fine until a runner rejects a feature it should have had.
+
+See docs/sophios_language_reference.md.
+"""
+from enum import StrEnum
+from typing import Final
+
+
+class CwlVersion(StrEnum):
+    """Every version the CWL `CWLVersion` enumeration admits.
+
+    Reproduced from the CWL v1.2 specification so a `cwlVersion` field can be
+    validated against the real set instead of "any non-empty string". Sophios
+    emits exactly one of these — `CWL_VERSION` — but must still recognise the
+    others when reading documents it did not write.
+
+    https://www.commonwl.org/v1.2/Workflow.html#CWLVersion
+    """
+
+    DRAFT_2 = 'draft-2'
+    DRAFT_3_DEV1 = 'draft-3.dev1'
+    DRAFT_3_DEV2 = 'draft-3.dev2'
+    DRAFT_3_DEV3 = 'draft-3.dev3'
+    DRAFT_3_DEV4 = 'draft-3.dev4'
+    DRAFT_3_DEV5 = 'draft-3.dev5'
+    DRAFT_3 = 'draft-3'
+    DRAFT_4_DEV1 = 'draft-4.dev1'
+    DRAFT_4_DEV2 = 'draft-4.dev2'
+    DRAFT_4_DEV3 = 'draft-4.dev3'
+    V1_0_DEV4 = 'v1.0.dev4'
+    V1_0 = 'v1.0'
+    V1_1_0_DEV1 = 'v1.1.0-dev1'
+    V1_1 = 'v1.1'
+    V1_2_0_DEV1 = 'v1.2.0-dev1'
+    V1_2_0_DEV2 = 'v1.2.0-dev2'
+    V1_2_0_DEV3 = 'v1.2.0-dev3'
+    V1_2_0_DEV4 = 'v1.2.0-dev4'
+    V1_2_0_DEV5 = 'v1.2.0-dev5'
+    V1_2 = 'v1.2'
+
+
+#: The version Sophios emits. Every generated document declares this one.
+#:
+#: A plain `str`, deliberately, not the enum member. `CwlVersion` is a
+#: `StrEnum`, so it compares and formats like a string — but PyYAML dispatches
+#: its representers on exact type, not `isinstance`, and refuses to serialise a
+#: subclass it was not told about. Emitting the member would put an object into
+#: every generated document that `yaml.safe_dump` cannot write. The enum stays
+#: for validation; what gets embedded is the value.
+CWL_VERSION: Final[str] = CwlVersion.V1_2.value
+
+#: Every admissible version as plain strings, for JSON Schema `enum` fields.
+CWL_VERSIONS: Final[tuple[str, ...]] = tuple(version.value for version in CwlVersion)

--- a/src/sophios/python_cwl_adapter.py
+++ b/src/sophios/python_cwl_adapter.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import sys
 from types import ModuleType
 from typing import Any
+from .lang.cwl import CWL_VERSION
 
 DRIVER_SCRIPT = '/python_cwl_driver.py'
 TYPES_SCRIPT = '/workflow_types.py'
@@ -114,7 +115,7 @@ def generate_CWL_CommandLineTool(module_inputs: dict[str, Any], module_outputs: 
         dict[str, Any]: A CWL CommandLineTool with the given inputs and outputs.
     """
     yaml_tree: dict[str, Any] = {}
-    yaml_tree['cwlVersion'] = 'v1.0'
+    yaml_tree['cwlVersion'] = CWL_VERSION
     yaml_tree['class'] = 'CommandLineTool'
     yaml_tree['$namespaces'] = {'edam': 'https://edamontology.org/'}
     yaml_tree['$schemas'] = ['https://raw.githubusercontent.com/edamontology/edamontology/master/EDAM_dev.owl']

--- a/src/sophios/schemas/wic_schema.py
+++ b/src/sophios/schemas/wic_schema.py
@@ -16,6 +16,7 @@ from sophios.cli import get_dicts_for_compilation
 from sophios.utils_yaml import wic_loader
 from sophios.wic_types import GraphData, GraphReps, NodeData, StepId, Yaml, YamlTree
 from ..wic_types import Json, Tools
+from ..lang.cwl import CWL_VERSIONS
 
 
 config_schemas = {}
@@ -526,7 +527,7 @@ def wic_main_schema(tools_cwl: Tools, yml_stems: list[str], schema_store: dict[s
 
     schema_props = {'steps': steps,
                     'class': str_nonempty,
-                    'cwlVersion': str_nonempty,  # TODO enum https://www.commonwl.org/v1.2/Workflow.html#CWLVersion
+                    'cwlVersion': {'enum': list(CWL_VERSIONS)},
                     # TODO https://www.commonwl.org/v1.2/SchemaSalad.html#Explicit_context
                     '$base': str_nonempty,
                     '$namespaces': {},  # TODO

--- a/tests/core/test_cwl_version.py
+++ b/tests/core/test_cwl_version.py
@@ -1,0 +1,171 @@
+"""Properties of the CWL substrate version (CR-102, T1.5).
+
+Properties covered:
+  P14  every emitting path declares the one substrate version
+
+The design specifies `.wic` as an abstraction over a single declared CWL version
+(`design_docs/core-refactor-design.md` §5.2). At baseline three sites disagreed:
+the compiler emitted `v1.2`, a CommandLineTool generator emitted `v1.0`, and the
+schema accepted any non-empty string.
+
+P14 is checked statically rather than by compiling something, because the
+failure it guards against is silent. A document declaring the wrong version is
+still valid YAML and still runs, right up until a runner rejects a feature it
+should have supported. A grep-shaped property catches the literal at the moment
+someone reintroduces it.
+"""
+import ast
+from pathlib import Path
+from typing import Final
+
+import pytest
+import yaml
+
+from sophios.lang.cwl import CWL_VERSION, CWL_VERSIONS, CwlVersion
+from sophios.python_cwl_adapter import generate_CWL_CommandLineTool
+
+REPO_ROOT: Final = Path(__file__).resolve().parents[2]
+SRC: Final = REPO_ROOT / 'src' / 'sophios'
+
+#: The one module allowed to contain version literals: it defines them.
+OWNER: Final = SRC / 'lang' / 'cwl.py'
+
+#: Keys that carry a CWL version, in either spelling.
+VERSION_KEYS: Final = frozenset({'cwlVersion', 'cwl_version'})
+
+
+def _python_files() -> list[Path]:
+    """Every Python file in the package except the module that owns the values."""
+    return sorted(path for path in SRC.rglob('*.py') if path != OWNER)
+
+
+def _version_constant(node: ast.expr | None) -> ast.Constant | None:
+    """The node itself if it is a CWL version string, else None."""
+    if isinstance(node, ast.Constant) and node.value in set(CWL_VERSIONS):
+        return node
+    return None
+
+
+def _target_name(target: ast.expr) -> str | None:
+    """The key or variable a value is being assigned to, if it has a simple name."""
+    match target:
+        case ast.Subscript(slice=ast.Constant(value=str() as key)):
+            return key
+        case ast.Name(id=name):
+            return name
+        case _:
+            return None
+
+
+def _version_literals(tree: ast.AST) -> list[tuple[int, str]]:
+    """Find every place a CWL version key is assigned a string literal.
+
+    Covers the four shapes the codebase actually used: subscript assignment
+    (`d['cwlVersion'] = ...`), a dict literal entry, an annotated assignment,
+    and a plain one.
+    """
+    found: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        match node:
+            case ast.Dict(keys=keys, values=values):
+                for key, value in zip(keys, values):
+                    constant = _version_constant(value)
+                    if constant is not None and isinstance(key, ast.Constant) and key.value in VERSION_KEYS:
+                        found.append((constant.lineno, str(constant.value)))
+            case ast.Assign(targets=targets, value=value):
+                constant = _version_constant(value)
+                if constant is not None and any(_target_name(t) in VERSION_KEYS for t in targets):
+                    found.append((constant.lineno, str(constant.value)))
+            case ast.AnnAssign(target=target, value=value):
+                constant = _version_constant(value)
+                if constant is not None and _target_name(target) in VERSION_KEYS:
+                    found.append((constant.lineno, str(constant.value)))
+    return found
+
+
+# --------------------------------------------------------------------------
+# P14
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('path', _python_files(), ids=lambda p: str(p.relative_to(SRC)))
+def test_p14_no_module_carries_its_own_cwl_version(path: Path) -> None:
+    """P14: only `lang/cwl.py` spells a CWL version; everyone else imports it.
+
+    A module that hardcodes its own is how `python_cwl_adapter.py` sat on
+    `v1.0` while the compiler emitted `v1.2` — the two never had to agree
+    because nothing made them.
+    """
+    literals = _version_literals(ast.parse(path.read_text(encoding='utf-8'), str(path)))
+    assert not literals, (
+        f'{path.relative_to(REPO_ROOT)} hardcodes a CWL version at '
+        f'{[f"line {line}: {value!r}" for line, value in literals]}; '
+        f'import CWL_VERSION from sophios.lang.cwl instead'
+    )
+
+
+@pytest.mark.fast
+def test_p14_the_scan_can_actually_fail() -> None:
+    """The scan detects each shape it claims to, so P14 is not vacuous."""
+    shapes = [
+        "d['cwlVersion'] = 'v1.0'",
+        "d = {'cwlVersion': 'v1.0'}",
+        "cwl_version: str = 'v1.0'",
+        "cwl_version = 'v1.0'",
+    ]
+    for source in shapes:
+        assert _version_literals(ast.parse(source)), f'scan missed: {source}'
+
+
+@pytest.mark.fast
+def test_p14_the_scan_ignores_unrelated_strings() -> None:
+    """A version-shaped string not bound to a version key is not a finding."""
+    assert not _version_literals(ast.parse("label = 'v1.0'"))
+    assert not _version_literals(ast.parse("d = {'other': 'v1.0'}"))
+
+
+# --------------------------------------------------------------------------
+# Sanity checks
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_the_declared_version_is_v1_2() -> None:
+    """§5.2 pins the substrate to CWL v1.2."""
+    assert CWL_VERSION == 'v1.2'
+    assert CWL_VERSION == CwlVersion.V1_2
+
+
+@pytest.mark.fast
+def test_the_version_serialises_as_a_plain_string() -> None:
+    """`CWL_VERSION` must survive a YAML dump unchanged.
+
+    This is the check that matters, and the one that `isinstance(x, str)` does
+    not make. PyYAML picks a representer by exact type, so a `StrEnum` member
+    compares equal to `'v1.2'`, formats as `v1.2`, and still raises
+    `RepresenterError` the moment a generated document is written to disk.
+    """
+    assert type(CWL_VERSION) is str  # pylint: disable=unidiomatic-typecheck
+    assert yaml.safe_dump({'cwlVersion': CWL_VERSION}) == "cwlVersion: v1.2\n"
+
+
+@pytest.mark.fast
+def test_a_generated_tool_declares_v1_2_and_dumps() -> None:
+    """The CommandLineTool generator emits v1.2, and its output serialises.
+
+    This generator is the one that was stuck on `v1.0`, and it is also where
+    an unserialisable version value would first reach disk.
+    """
+    tool = generate_CWL_CommandLineTool({}, {})
+    assert tool['cwlVersion'] == 'v1.2'
+    assert 'cwlVersion: v1.2' in yaml.safe_dump(tool)
+
+
+@pytest.mark.fast
+def test_every_real_cwl_version_is_admitted() -> None:
+    """The enum covers the CWL spec's own list, so reading a foreign document
+    that legitimately declares an older version is not an error."""
+    for version in ('draft-2', 'v1.0', 'v1.1', 'v1.2', 'v1.2.0-dev5'):
+        assert version in CWL_VERSIONS


### PR DESCRIPTION
Stacks on #3 (`semrefac_2`); the single commit after its tip is this PR.

A specification written against an unspecified CWL version specifies nothing, and at baseline the version was genuinely unspecified: the compiler emitted `v1.2` for workflows, `python_cwl_adapter.py` hardcoded `v1.0` for generated CommandLineTools, and the schema validated `cwlVersion` as any non-empty string, so a typo passed review and validation alike. `lang/cwl.py` now owns the declared substrate version and the enumeration of every version CWL itself admits; the five emitting paths import the value, `cwlVersion` is validated as an enum, and the CommandLineTool generator moves from v1.0 to v1.2 — which is the correction the design calls for, not a migration.

The guard is a static scan asserting no module outside `lang/cwl.py` carries its own version literal, because the failure it prevents is silent: a document declaring the wrong version still parses and still runs until a runner rejects a feature it should have had. The scan is itself tested against each assignment shape it claims to catch, so it cannot pass by finding nothing. One implementation note recorded in the tracker as CE-04: the exported constant is a plain `str`, not the `StrEnum` member, because PyYAML selects representers by exact type and refuses a subclass it was not told about — the member compares equal to `'v1.2'`, formats identically, satisfies `isinstance(x, str)`, and still cannot be serialised; the regression test now dumps rather than asking `isinstance`.
