### PR TITLE
Spec 1: one source of truth for the surface, and namespaced, immutable shared state

### DIFF
--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -276,9 +276,29 @@ example — see `tests/core/test_lang_parser.py`.
 ### 6.3 The machine-readable schema
 
 `sophios.lang.wic_schema()` exports a JSON Schema for editors. It is generated
-from the parser's own tables — the construct keys, the interpreted step keys,
-the `wic:` step-key pattern — so a construct added to the parser appears in the
-schema without anyone editing a schema file. There is no hand-maintained copy.
+from the AST, not written by hand.
+
+Every field of every AST node declares how it is written, next to the field
+itself:
+
+```python
+class Step:
+    id:      ... = surface(Shape.IDENTITY,        'id')
+    inputs:  ... = surface(Shape.INPUT_BINDINGS,  'in')
+    outputs: ... = surface(Shape.OUTPUT_BINDINGS, 'out')
+    passthrough: ... = surface(Shape.PASSTHROUGH)      # every unclaimed key
+    span:        ... = surface(Shape.INTERNAL)         # not syntax at all
+```
+
+That declaration is the single source of truth for the mapping between the AST
+and the surface, and it is what this document's tables describe in English.
+The schema generator walks those declarations; the construct keys and the
+`wic:` step-key pattern come from the parser's own tables. Nothing restates the
+shape of a document a second time, so nothing can disagree about it.
+
+Add a field to a node and one of two things happens: the schema gains the key,
+or generation fails because the field never said how it is written. There is no
+third outcome in which the schema quietly describes an older language.
 
 It is an **over-approximation**, for two reasons that come from the language
 itself rather than from any shortcut:

--- a/src/sophios/compiler.py
+++ b/src/sophios/compiler.py
@@ -12,7 +12,7 @@ import yaml
 
 from . import input_output as io
 from . import inference, utils, utils_cwl, utils_graphs
-from .utils_yaml import KEY_ALIAS, KEY_INLINE_INPUT
+from .utils_yaml import Key
 from .wic_types import (CompilerInfo, CompilerOptions, EnvData, ExplicitEdgeCalls,
                         ExplicitEdgeDefs, GraphData, GraphReps, GraphSettings, Namespaces,
                         NodeData, RoseTree, Tool, Tools, WorkflowInputs, WorkflowInputsFile,
@@ -683,9 +683,9 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
 
             # Convert native YAML to a JSON-encoded string for specific tags.
             tags = ['config']
-            if arg_key in tags and isinstance(arg_val, dict) and (KEY_INLINE_INPUT in arg_val):
-                arg_val = {KEY_INLINE_INPUT: json.dumps(
-                    arg_val[KEY_INLINE_INPUT])}
+            if arg_key in tags and isinstance(arg_val, dict) and (Key.INLINE_INPUT in arg_val):
+                arg_val = {Key.INLINE_INPUT: json.dumps(
+                    arg_val[Key.INLINE_INPUT])}
 
             # Use triple underscore for namespacing so we can split later
             in_name = f'{step_name_or_key}___{arg_key}'
@@ -703,11 +703,11 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
                 in_tool[arg_key], True)
 
             # NOTE: match-mapping patterns require literal keys, so the
-            # KEY_ALIAS / KEY_INLINE_INPUT constants cannot be used in the
+            # Key.ALIAS / Key.INLINE_INPUT constants cannot be used in the
             # `case` patterns themselves (only where compared/indexed below).
             match arg_val:
                 case {'wic_alias': _}:
-                    arg_val = arg_val[KEY_ALIAS]
+                    arg_val = arg_val[Key.ALIAS]
                     if not setup.explicit_edge_defs_copy.get(arg_val):
                         if is_root and not testing:
                             # Even if is_root, we don't want to raise an Exception
@@ -822,7 +822,7 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
                             utils_graphs.add_graph_edge(
                                 graph_settings, graph_init, nss_def, nss_call, label, color='blue')
                 case {'wic_inline_input': _}:
-                    arg_val = arg_val[KEY_INLINE_INPUT]
+                    arg_val = arg_val[Key.INLINE_INPUT]
 
                     if arg_key in setup.steps[i].get('scatter', []):
                         # Promote scattered input types to arrays

--- a/src/sophios/contrib/converter.py
+++ b/src/sophios/contrib/converter.py
@@ -6,7 +6,7 @@ from typing import Any
 import json
 import yaml
 from jsonschema import Draft202012Validator
-from sophios.utils_yaml import wic_loader, TAG_ANCHOR, TAG_ALIAS, TAG_INLINE_INPUT, KEY_ANCHOR
+from sophios.utils_yaml import Key, Tag, wic_loader
 
 from sophios.wic_types import Json, Cwl, PluginNodeConfig
 from sophios.contrib.ict.ict_spec.model import ICT
@@ -172,7 +172,7 @@ def get_topological_order(links: list[dict[str, str]]) -> list[str]:
 
 
 def _tag_value(tag: str, value: Any) -> dict:
-    """Tag a value with a wic yaml tag (TAG_ANCHOR/TAG_ALIAS/TAG_INLINE_INPUT)."""
+    """Tag a value with a wic yaml tag (Tag.ANCHOR/Tag.ALIAS/Tag.INLINE_INPUT)."""
     tagged: dict = yaml.load(f'{tag} ' + str(value), Loader=wic_loader())
     return tagged
 
@@ -188,8 +188,8 @@ def _find_edge_nodes(edge: Json, nodes: list[Json]) -> tuple[Json, Json]:
 
 def _resolve_wic_anchor(value: Any) -> Any:
     """Unwrap a `!&`-tagged (wic_anchor) output value to its underlying value."""
-    if isinstance(value, dict) and KEY_ANCHOR in value:
-        return value[KEY_ANCHOR]
+    if isinstance(value, dict) and Key.ANCHOR in value:
+        return value[Key.ANCHOR]
     return value
 
 
@@ -236,7 +236,7 @@ def wfb_to_wic(wfb_payload: Json, plugins: list[dict[str, Any]]) -> Cwl:
         if node.get('settings'):
             node['in'] = node['settings'].get('inputs')
             if node['settings'].get('outputs'):
-                node['out'] = list({k: _tag_value(TAG_ANCHOR, v)} for k, v in node['settings']
+                node['out'] = list({k: _tag_value(Tag.ANCHOR, v)} for k, v in node['settings']
                                    # outputs always have to be list
                                    ['outputs'].items())
             # remove these (now) superfluous keys
@@ -258,7 +258,7 @@ def wfb_to_wic(wfb_payload: Json, plugins: list[dict[str, Any]]) -> Cwl:
         if node.get('in'):
             for nkey in node['in']:
                 if str(node['in'][nkey]) != "":
-                    node['in'][nkey] = _tag_value(TAG_INLINE_INPUT, node['in'][nkey])
+                    node['in'][nkey] = _tag_value(Tag.INLINE_INPUT, node['in'][nkey])
                     node_arg_map[node['id']].add(nkey)
 
     if plugins != []:  # use the look up logic similar to WFB
@@ -284,14 +284,14 @@ def wfb_to_wic(wfb_payload: Json, plugins: list[dict[str, Any]]) -> Cwl:
 
                 if tgt_node.get('in'):
                     source_output = _resolve_wic_anchor(src_node['out'][0][src_node_out_arg])
-                    tgt_node['in'][tgt_node_in_arg] = _tag_value(TAG_ALIAS, source_output)
+                    tgt_node['in'][tgt_node_in_arg] = _tag_value(Tag.ALIAS, source_output)
                     node_arg_map[tgt_id].add(tgt_node_in_arg)
 
         for node in inp_restrict['nodes']:
             output_dict = node['settings'].get('outputs', {})
             for key in output_dict:
                 if str(output_dict[key]) != "":
-                    node['in'][key] = _tag_value(TAG_INLINE_INPUT, output_dict[key])
+                    node['in'][key] = _tag_value(Tag.INLINE_INPUT, output_dict[key])
                     node_arg_map[node['id']].add(key)
             node.pop('settings', None)
 
@@ -301,7 +301,7 @@ def wfb_to_wic(wfb_payload: Json, plugins: list[dict[str, Any]]) -> Cwl:
                     unprocessed_args = unprocessed_args.difference(
                         node_arg_map[node['id']])
                 for arg in unprocessed_args:
-                    node['in'][arg] = _tag_value(TAG_INLINE_INPUT, node['in'][arg])
+                    node['in'][arg] = _tag_value(Tag.INLINE_INPUT, node['in'][arg])
     else:  # No plugins, use the node/link mapping directly.
         for node in inp_restrict['nodes']:
             node.pop('settings', None)
@@ -322,12 +322,12 @@ def wfb_to_wic(wfb_payload: Json, plugins: list[dict[str, Any]]) -> Cwl:
                         # if the output is a dict, it is a wic_anchor, so we need to get the anchor
                         # and use that as the input
                         source_output = _resolve_wic_anchor(src_node['out'][0][sk])
-                        tgt_node['in'][sk] = _tag_value(TAG_ALIAS, source_output)
+                        tgt_node['in'][sk] = _tag_value(Tag.ALIAS, source_output)
                 # the inputs which aren't dependent on previous/other steps
                 # they are by default inline input
                 diff_keys = set(tgt_in_keys) - set(src_out_keys)
                 for dfk in diff_keys:
-                    tgt_node['in'][dfk] = _tag_value(TAG_INLINE_INPUT, tgt_node['in'][dfk])
+                    tgt_node['in'][dfk] = _tag_value(Tag.INLINE_INPUT, tgt_node['in'][dfk])
 
     workflow_temp: Cwl = {}
     if inp_restrict["links"] != []:

--- a/src/sophios/lang/__init__.py
+++ b/src/sophios/lang/__init__.py
@@ -26,14 +26,8 @@ from .nodes import (
     UnresolvedName,
     WicSidecar,
 )
-from .parser import (
-    DESUGARED_KEYS,
-    INTERPRETED_STEP_KEYS,
-    TAG_RAW_CWL,
-    WIC_STEP_KEY_PATTERN,
-    ParseResult,
-    parse,
-)
+from ..utils_yaml import Key, Tag
+from .parser import Forms, Grammar, ParseResult, parse
 from .render import render, to_json
 from .schema import wic_schema
 from .spans import SourceSpan
@@ -42,14 +36,13 @@ __all__ = [
     'CWL_VERSION',
     'CWL_VERSIONS',
     'CwlVersion',
-    'DESUGARED_KEYS',
-    'INTERPRETED_STEP_KEYS',
-    'TAG_RAW_CWL',
-    'WIC_STEP_KEY_PATTERN',
     'Code',
     'Diagnostic',
     'Diagnostics',
+    'Key',
     'Document',
+    'Forms',
+    'Grammar',
     'EdgeDef',
     'EdgeRef',
     'InlineLiteral',
@@ -62,6 +55,7 @@ __all__ = [
     'SourceSpan',
     'Step',
     'StepKey',
+    'Tag',
     'UnresolvedName',
     'WicSidecar',
     'parse',

--- a/src/sophios/lang/nodes.py
+++ b/src/sophios/lang/nodes.py
@@ -9,34 +9,110 @@ mutate is not a specification of anything; slotted because these are allocated
 once per construct in a document and the dict-per-instance overhead is pure
 waste.
 """
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
+from enum import StrEnum
 from typing import Any, TypeAlias
 
 from .spans import SourceSpan
+
+
+class Shape(StrEnum):
+    """What a field looks like in the YAML surface.
+
+    Semantic, not serialisation-specific: this says *what kind of thing* a
+    field is, and downstream consumers decide how to express it. A JSON Schema
+    generator turns `INPUT_BINDINGS` into an object of input values; a
+    different consumer could turn it into something else. Neither gets to
+    invent the fact that `Step.inputs` is spelled `in:`.
+    """
+
+    #: Not surface syntax at all — source spans, surface-form flags.
+    INTERNAL = 'internal'
+    #: The node's own name, carried by its position rather than a key.
+    IDENTITY = 'identity'
+    #: `in:` — a mapping of input name to one of the five input forms.
+    INPUT_BINDINGS = 'input_bindings'
+    #: `out:` — a sequence of bare names or single-key edge bindings.
+    OUTPUT_BINDINGS = 'output_bindings'
+    #: `steps:` — a mapping keyed by step name, or a sequence.
+    STEPS = 'steps'
+    #: `wic:` — the metadata sidecar.
+    SIDECAR = 'sidecar'
+    #: `wic: steps:` — a mapping keyed by `(index, name)`.
+    SIDECAR_STEPS = 'sidecar_steps'
+    #: A fixed set of CWL keys Sophios reads and acts upon.
+    INTERPRETED = 'interpreted'
+    #: Any key not claimed above: CWL, copied through untouched.
+    PASSTHROUGH = 'passthrough'
+
+
+@dataclass(frozen=True, slots=True)
+class Surface:
+    """How one AST field appears in the language's YAML surface.
+
+    Declared beside the field it describes, so the mapping between the AST and
+    the syntax lives in exactly one place. Everything that needs to know the
+    shape of a document — the exported JSON Schema, the reference table —
+    reads this rather than restating it.
+    """
+
+    shape: Shape
+    #: The surface key this field occupies, when it occupies exactly one.
+    key: str | None = None
+
+
+def surface(shape: Shape, key: str | None = None, **kwargs: Any) -> Any:
+    """Declare a field's surface form. Thin wrapper over `dataclasses.field`.
+
+    The `field()` call is made here rather than at each use site so that every
+    declaration is one readable line. Pylint expects `field()` to appear
+    literally inside a class body and cannot see through the indirection.
+    """
+    # pylint: disable=invalid-field-call
+    return field(metadata={'surface': Surface(shape, key)}, **kwargs)
+
+
+def surface_of(node_type: type, field_name: str) -> Surface:
+    """The declared surface form of one field.
+
+    Raises if the field was never declared. That is the point: a field added
+    to a node without saying how it is written is a hole in the specification,
+    and it should stop the build rather than silently widen the language.
+    """
+    for declared in fields(node_type):
+        if declared.name == field_name:
+            found = declared.metadata.get('surface')
+            if found is None:
+                raise TypeError(
+                    f'{node_type.__name__}.{field_name} has no surface declaration; '
+                    f'add one with surface(Shape.…) so downstream consumers can see it'
+                )
+            return found  # type: ignore[no-any-return]
+    raise AttributeError(f'{node_type.__name__} has no field {field_name!r}')
 
 
 @dataclass(frozen=True, slots=True)
 class InlineLiteral:
     """`!ii value` — a literal, never an edge."""
 
-    value: Any
-    span: SourceSpan
+    value: Any = surface(Shape.IDENTITY)
+    span: SourceSpan = surface(Shape.INTERNAL)
 
 
 @dataclass(frozen=True, slots=True)
 class EdgeDef:
     """`!& name` — an explicit edge definition site."""
 
-    name: str
-    span: SourceSpan
+    name: str = surface(Shape.IDENTITY)
+    span: SourceSpan = surface(Shape.INTERNAL)
 
 
 @dataclass(frozen=True, slots=True)
 class EdgeRef:
     """`!* name` — an explicit edge call site."""
 
-    name: str
-    span: SourceSpan
+    name: str = surface(Shape.IDENTITY)
+    span: SourceSpan = surface(Shape.INTERNAL)
 
 
 @dataclass(frozen=True, slots=True)
@@ -47,8 +123,8 @@ class RawCwlRef:
     local, visible form of what `--allow_raw_cwl` does globally.
     """
 
-    expression: str
-    span: SourceSpan
+    expression: str = surface(Shape.IDENTITY)
+    span: SourceSpan = surface(Shape.INTERNAL)
 
 
 @dataclass(frozen=True, slots=True)
@@ -59,8 +135,8 @@ class UnresolvedName:
     `!ii` for a literal, `!cwl` for a raw CWL reference.
     """
 
-    name: str
-    span: SourceSpan
+    name: str = surface(Shape.IDENTITY)
+    span: SourceSpan = surface(Shape.INTERNAL)
 
 
 #: The complete set of forms a step input may take. Closed by construction:
@@ -81,9 +157,9 @@ class OutputBinding:
     an edge definition (`- file: !& file_touch`).
     """
 
-    name: str
-    edge_def: EdgeDef | None
-    span: SourceSpan
+    name: str = surface(Shape.IDENTITY)
+    edge_def: EdgeDef | None = surface(Shape.IDENTITY)
+    span: SourceSpan = surface(Shape.INTERNAL)
 
 
 @dataclass(frozen=True, slots=True)
@@ -95,12 +171,12 @@ class Step:
     preserved verbatim.
     """
 
-    id: str
-    inputs: tuple[tuple[str, InputValue], ...] = ()
-    outputs: tuple[OutputBinding, ...] = ()
-    interpreted: tuple[tuple[str, OpaqueCwl], ...] = ()
-    passthrough: tuple[tuple[str, OpaqueCwl], ...] = ()
-    span: SourceSpan | None = None
+    id: str = surface(Shape.IDENTITY, 'id')
+    inputs: tuple[tuple[str, InputValue], ...] = surface(Shape.INPUT_BINDINGS, 'in', default=())
+    outputs: tuple[OutputBinding, ...] = surface(Shape.OUTPUT_BINDINGS, 'out', default=())
+    interpreted: tuple[tuple[str, OpaqueCwl], ...] = surface(Shape.INTERPRETED, default=())
+    passthrough: tuple[tuple[str, OpaqueCwl], ...] = surface(Shape.PASSTHROUGH, default=())
+    span: SourceSpan | None = surface(Shape.INTERNAL, default=None)
 
     def input(self, name: str) -> InputValue | None:
         """Return the value bound to `name`, or None if unbound."""
@@ -115,8 +191,8 @@ class StepKey:
     should ever parse that string again.
     """
 
-    index: int
-    name: str
+    index: int = surface(Shape.IDENTITY)
+    name: str = surface(Shape.IDENTITY)
 
     def __str__(self) -> str:
         return f'({self.index}, {self.name})'
@@ -131,9 +207,9 @@ class WicSidecar:
     the sidecar's surface is unchanged by this specification.
     """
 
-    steps: tuple[tuple[StepKey, 'WicSidecar'], ...] = ()
-    entries: tuple[tuple[str, OpaqueCwl], ...] = ()
-    span: SourceSpan | None = None
+    steps: tuple[tuple[StepKey, 'WicSidecar'], ...] = surface(Shape.SIDECAR_STEPS, 'steps', default=())
+    entries: tuple[tuple[str, OpaqueCwl], ...] = surface(Shape.PASSTHROUGH, default=())
+    span: SourceSpan | None = surface(Shape.INTERNAL, default=None)
 
     def entry(self, name: str) -> OpaqueCwl | None:
         """Return a non-`steps` sidecar entry by name."""
@@ -149,12 +225,12 @@ class Document:
     preserved so it can be emitted unchanged.
     """
 
-    steps: tuple[Step, ...] = ()
-    sidecar: WicSidecar | None = None
-    passthrough: tuple[tuple[str, OpaqueCwl], ...] = ()
-    span: SourceSpan | None = None
+    steps: tuple[Step, ...] = surface(Shape.STEPS, 'steps', default=())
+    sidecar: WicSidecar | None = surface(Shape.SIDECAR, 'wic', default=None)
+    passthrough: tuple[tuple[str, OpaqueCwl], ...] = surface(Shape.PASSTHROUGH, default=())
+    span: SourceSpan | None = surface(Shape.INTERNAL, default=None)
     #: True when `steps:` was written as a mapping rather than a sequence.
-    steps_as_mapping: bool = field(default=False)
+    steps_as_mapping: bool = surface(Shape.INTERNAL, default=False)
 
     def step(self, step_id: str) -> Step | None:
         """Return the first step with the given id, or None."""

--- a/src/sophios/lang/parser.py
+++ b/src/sophios/lang/parser.py
@@ -10,11 +10,12 @@ See design_docs/core-refactor-design.md, Spec 1.
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Final
+from types import MappingProxyType
+from typing import Any, Final, Mapping, TypeAlias, final
 
 import yaml
 
-from ..utils_yaml import KEY_ALIAS, KEY_ANCHOR, KEY_INLINE_INPUT, TAG_ALIAS, TAG_ANCHOR, TAG_INLINE_INPUT
+from ..utils_yaml import Key, Tag
 from .diagnostics import Code, Diagnostics
 from .nodes import (
     Document,
@@ -32,32 +33,37 @@ from .nodes import (
 )
 from .spans import SourceSpan
 
-#: `!cwl expr` — the per-value escape hatch. Additive: files that do not use it
-#: are unaffected, and it is the local form of the global --allow_raw_cwl flag.
-TAG_RAW_CWL: Final = '!cwl'
 
-#: The desugared key for `!cwl`, mirroring KEY_ANCHOR / KEY_ALIAS /
-#: KEY_INLINE_INPUT in utils_yaml. Every construct has both a tagged and a
-#: desugared form so the Python API can emit documents that reload unchanged.
-KEY_RAW_CWL: Final = 'wic_raw_cwl'
+@final
+class Grammar:  # pylint: disable=too-few-public-methods  # a namespace, not a type
+    """The syntax layer's fixed vocabulary.
 
-#: CWL keys on a step that Sophios reads *and acts upon*. Everything else on a
-#: step is passthrough, by definition. Enumerating this set is what makes the
-#: leak boundary a specification rather than an accident.
-INTERPRETED_STEP_KEYS: Final = frozenset({'scatter', 'scatterMethod', 'when', 'run'})
+    A namespace rather than loose module constants: these describe one thing —
+    what the language admits — and reading them together is how you check that.
+    Every member is immutable and built once at import, so they are shared
+    safely across threads and survive `fork` without coordination.
+    """
 
-#: `wic:` sidecar step keys have the surface form "(1, step_name)".
-_WIC_STEP_KEY: Final = re.compile(r'^\(\s*(\d+)\s*,\s*(.+?)\s*\)$')
+    #: CWL keys on a step that Sophios reads *and acts upon*. Everything else
+    #: on a step is passthrough, by definition. Enumerating this set is what
+    #: makes the leak boundary a specification rather than an accident.
+    INTERPRETED_STEP_KEYS: Final = frozenset({'scatter', 'scatterMethod', 'when', 'run'})
 
-#: How YAML's resolved scalar tags map to Python values. Annotated explicitly
-#: because the converters are heterogeneous and would otherwise infer as
-#: `object`, which is not callable.
-_SCALAR_TAGS: Final[dict[str, Callable[[str], Any]]] = {
-    'tag:yaml.org,2002:null': lambda _: None,
-    'tag:yaml.org,2002:bool': lambda s: s.lower() in ('true', 'yes', 'on'),
-    'tag:yaml.org,2002:int': int,
-    'tag:yaml.org,2002:float': float,
-}
+    #: `wic:` sidecar step keys have the surface form "(1, step_name)".
+    WIC_STEP_KEY: Final = re.compile(r'^\(\s*(\d+)\s*,\s*(.+?)\s*\)$')
+
+    #: The same rule as a string, for consumers that need to state it rather
+    #: than apply it — the exported JSON Schema, principally.
+    WIC_STEP_KEY_PATTERN: Final = WIC_STEP_KEY.pattern
+
+    #: How YAML's resolved scalar tags map to Python values. A read-only view:
+    #: a module-level dict any caller could mutate is a race waiting to happen.
+    SCALAR_TAGS: Final[Mapping[str, Callable[[str], Any]]] = MappingProxyType({
+        'tag:yaml.org,2002:null': lambda _: None,
+        'tag:yaml.org,2002:bool': lambda s: s.lower() in ('true', 'yes', 'on'),
+        'tag:yaml.org,2002:int': int,
+        'tag:yaml.org,2002:float': float,
+    })
 
 
 @dataclass(frozen=True, slots=True)
@@ -228,7 +234,7 @@ def _step_body(
             inputs = _inputs(value_node, file, diags)
         elif key == 'out':
             outputs = _outputs(value_node, file, diags)
-        elif key in INTERPRETED_STEP_KEYS:
+        elif key in Grammar.INTERPRETED_STEP_KEYS:
             interpreted.append((key, _opaque(value_node, file, diags)))
         else:
             passthrough.append((key, _opaque(value_node, file, diags)))
@@ -285,7 +291,7 @@ def _input_value(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> InputV
     """
     span = SourceSpan.of(file, node)
 
-    build = _TAGGED_FORMS.get(node.tag)
+    build = Forms.TAGGED.get(node.tag)
     if build is not None:
         return build(node, file, diags, span)
 
@@ -310,39 +316,45 @@ def _desugared_form(
     if not isinstance(node, yaml.nodes.MappingNode) or len(node.value) != 1:
         return None
     key_node, value_node = node.value[0]
-    build = _DESUGARED_FORMS.get(_key_text(key_node))
+    build = Forms.DESUGARED.get(_key_text(key_node))
     if build is None:
         return None
     return build(value_node, file, diags, span)
 
 
-#: Tagged spellings to the node they build, paired with _DESUGARED_FORMS below.
-#: A table rather than a comparison chain: one lookup instead of four, and the
-#: two spellings of each construct stay side by side.
-_TAGGED_FORMS: Final[dict[str, Callable[[yaml.nodes.Node, str, Diagnostics, SourceSpan], InputValue]]] = {
-    TAG_INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_literal(n, f, d), s),
-    TAG_ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
-    TAG_ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
-    TAG_RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
-}
+#: One builder: a YAML node and its context in, one input node out.
+Builder: TypeAlias = Callable[[yaml.nodes.Node, str, Diagnostics, SourceSpan], InputValue]
 
-#: Desugared keys to the node they build. A table rather than a branch chain:
-#: adding a construct means adding a row, and the tagged and desugared spellings
-#: stay visibly paired.
-_DESUGARED_FORMS: Final[dict[str, Callable[[yaml.nodes.Node, str, Diagnostics, SourceSpan], InputValue]]] = {
-    KEY_INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_opaque(n, f, d), s),
-    KEY_ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
-    KEY_ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
-    KEY_RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
-}
 
-#: The desugared construct keys, as a set. Derived from the table above so a
-#: construct added there needs no second edit anywhere else.
-DESUGARED_KEYS: Final = frozenset(_DESUGARED_FORMS)
+@final
+class Forms:  # pylint: disable=too-few-public-methods  # a namespace, not a type
+    """Each construct's two spellings, and what each builds.
 
-#: The regular expression a `wic: steps:` key must match, for consumers that
-#: need to state the rule rather than apply it.
-WIC_STEP_KEY_PATTERN: Final = _WIC_STEP_KEY.pattern
+    Kept side by side and in one namespace because the language's claim is that
+    the two spellings are equivalent (§6.1). Splitting them into separate
+    module globals is how they drift apart — which is exactly the defect CE-02
+    recorded. Both tables are read-only views.
+    """
+
+    #: Tagged spellings — what people write.
+    TAGGED: Final[Mapping[str, Builder]] = MappingProxyType({
+        Tag.INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_literal(n, f, d), s),
+        Tag.ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
+        Tag.ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
+        Tag.RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
+    })
+
+    #: Desugared spellings — what tooling emits.
+    DESUGARED: Final[Mapping[str, Builder]] = MappingProxyType({
+        Key.INLINE_INPUT: lambda n, f, d, s: InlineLiteral(_opaque(n, f, d), s),
+        Key.ANCHOR: lambda n, _f, _d, s: EdgeDef(_name_text(n), s),
+        Key.ALIAS: lambda n, _f, _d, s: EdgeRef(_name_text(n), s),
+        Key.RAW_CWL: lambda n, _f, _d, s: RawCwlRef(_name_text(n), s),
+    })
+
+    #: The desugared construct keys. Derived from the table above so a
+    #: construct added there needs no second edit anywhere else.
+    DESUGARED_KEYS: Final = frozenset(DESUGARED)
 
 
 def _outputs(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> tuple[OutputBinding, ...]:
@@ -361,7 +373,7 @@ def _output_binding(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> Out
             return OutputBinding(node.value, None, span)
         case yaml.nodes.MappingNode() if len(node.value) == 1:
             key_node, value_node = node.value[0]
-            edge = value_node.tag == TAG_ANCHOR
+            edge = value_node.tag == Tag.ANCHOR
             return OutputBinding(
                 _key_text(key_node),
                 EdgeDef(_name_text(value_node), SourceSpan.of(file, value_node)) if edge else None,
@@ -417,7 +429,7 @@ def _sidecar(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> WicSidecar
 
 def _step_key(text: str) -> StepKey | None:
     """Normalise a `"(1, name)"` sidecar key, or None if it is malformed."""
-    match = _WIC_STEP_KEY.match(text)
+    match = Grammar.WIC_STEP_KEY.match(text)
     if match is None:
         return None
     return StepKey(int(match.group(1)), match.group(2))
@@ -456,7 +468,7 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> OpaqueCwl:
     """
     match node:
         case yaml.nodes.ScalarNode():
-            if node.tag in (TAG_ANCHOR, TAG_ALIAS, TAG_INLINE_INPUT, TAG_RAW_CWL):
+            if node.tag in (Tag.ANCHOR, Tag.ALIAS, Tag.INLINE_INPUT, Tag.RAW_CWL):
                 return _input_value(node, file, diags)
             return _tagged_scalar(node)
         case yaml.nodes.SequenceNode():
@@ -470,7 +482,7 @@ def _opaque(node: yaml.nodes.Node, file: str, diags: Diagnostics) -> OpaqueCwl:
 
 def _tagged_scalar(node: yaml.nodes.ScalarNode) -> Any:
     """Convert a resolved scalar node to its Python value."""
-    convert = _SCALAR_TAGS.get(node.tag)
+    convert = Grammar.SCALAR_TAGS.get(node.tag)
     if convert is None:
         return node.value
     try:

--- a/src/sophios/lang/render.py
+++ b/src/sophios/lang/render.py
@@ -21,18 +21,11 @@ See docs/sophios_language_reference.md.
 import re
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Final, TypeAlias
+from typing import Any, Final, TypeAlias, final
 
 import yaml
 
-from ..utils_yaml import (
-    KEY_ALIAS,
-    KEY_ANCHOR,
-    KEY_INLINE_INPUT,
-    TAG_ALIAS,
-    TAG_ANCHOR,
-    TAG_INLINE_INPUT,
-)
+from ..utils_yaml import Key, Tag
 from .nodes import (
     Document,
     EdgeDef,
@@ -46,18 +39,26 @@ from .nodes import (
     UnresolvedName,
     WicSidecar,
 )
-from .parser import KEY_RAW_CWL, TAG_RAW_CWL
 
 #: How one input value is spelled. The two implementations below are the
 #: tagged and desugared surface forms of the same construct.
 Spelling: TypeAlias = Callable[[InputValue], Any]
 
-#: Every tag the tagged spelling emits.
-_WIC_TAGS: Final = frozenset({TAG_INLINE_INPUT, TAG_ANCHOR, TAG_ALIAS, TAG_RAW_CWL})
 
-#: Text needing no quoting after a tag: no leading YAML indicator, no
-#: whitespace, and nothing that would start a comment or end the scalar.
-_PLAIN_SAFE: Final = re.compile(r'[A-Za-z0-9_][A-Za-z0-9_./-]*\Z')
+@final
+class _Emit:  # pylint: disable=too-few-public-methods  # a namespace, not a type
+    """Everything the emitter needs to decide how to write a value.
+
+    Grouped so the two rules that govern output style sit together, and
+    immutable so they can be read from any thread without coordination.
+    """
+
+    #: Every tag the tagged spelling emits.
+    WIC_TAGS: Final = Tag.ALL
+
+    #: Text needing no quoting after a tag: no leading YAML indicator, no
+    #: whitespace, and nothing that would start a comment or end the scalar.
+    PLAIN_SAFE: Final = re.compile(r'[A-Za-z0-9_][A-Za-z0-9_./-]*\Z')
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,17 +78,17 @@ def _tagged(value: InputValue) -> Any:
     """Spell an input value with its YAML tag, as people write it."""
     match value:
         case InlineLiteral(value=literal) if _is_scalar(literal):
-            return _Tagged(TAG_INLINE_INPUT, _scalar_text(literal))
+            return _Tagged(Tag.INLINE_INPUT, _scalar_text(literal))
         case InlineLiteral(value=literal):
             # A tag cannot carry a collection on one line, so the single case
             # the tagged spelling cannot express falls back to the other one.
-            return {KEY_INLINE_INPUT: literal}
+            return {Key.INLINE_INPUT: literal}
         case EdgeDef(name=name):
-            return _Tagged(TAG_ANCHOR, name)
+            return _Tagged(Tag.ANCHOR, name)
         case EdgeRef(name=name):
-            return _Tagged(TAG_ALIAS, name)
+            return _Tagged(Tag.ALIAS, name)
         case RawCwlRef(expression=expression):
-            return _Tagged(TAG_RAW_CWL, expression)
+            return _Tagged(Tag.RAW_CWL, expression)
         case UnresolvedName(name=name):
             return name
 
@@ -96,13 +97,13 @@ def _desugared(value: InputValue) -> Any:
     """Spell an input value as a single-key mapping, as tooling emits it."""
     match value:
         case InlineLiteral(value=literal):
-            return {KEY_INLINE_INPUT: literal}
+            return {Key.INLINE_INPUT: literal}
         case EdgeDef(name=name):
-            return {KEY_ANCHOR: name}
+            return {Key.ANCHOR: name}
         case EdgeRef(name=name):
-            return {KEY_ALIAS: name}
+            return {Key.ALIAS: name}
         case RawCwlRef(expression=expression):
-            return {KEY_RAW_CWL: expression}
+            return {Key.RAW_CWL: expression}
         case UnresolvedName(name=name):
             return name
 
@@ -183,7 +184,7 @@ class _Writer:
 
 def _represent_tagged(dumper: yaml.SafeDumper, data: _Tagged) -> yaml.nodes.Node:
     """Emit a `_Tagged` as `!tag value`."""
-    style = '' if _PLAIN_SAFE.match(data.value) else None
+    style = '' if _Emit.PLAIN_SAFE.match(data.value) else None
     return dumper.represent_scalar(data.tag, data.value, style=style)
 
 
@@ -203,7 +204,7 @@ class _WicDumper(yaml.SafeDumper):
         tags whenever the value analyses as safe to write bare.
         """
         event = self.event
-        if isinstance(event, yaml.events.ScalarEvent) and event.tag in _WIC_TAGS and event.style == '':
+        if isinstance(event, yaml.events.ScalarEvent) and event.tag in _Emit.WIC_TAGS and event.style == '':
             if self.analysis is None:
                 self.analysis = self.analyze_scalar(event.value)
             if self.analysis.allow_block_plain:

--- a/src/sophios/lang/schema.py
+++ b/src/sophios/lang/schema.py
@@ -1,9 +1,11 @@
-"""Export a JSON Schema for Sophios, derived from the language definition.
+"""Export a JSON Schema for Sophios, generated from the AST.
 
-The schema is generated from the same constants the parser dispatches on — the
-desugared construct keys, the interpreted step keys, the `wic:` step-key
-pattern — so it cannot drift from the parser by being edited separately. There
-is no hand-maintained schema document anywhere in the tree.
+The AST is the source of truth. Every key in the exported schema comes from a
+field's `Surface` declaration in `nodes.py`, and every construct comes from the
+parser's dispatch tables — nothing here restates the shape of a document, so
+nothing here can disagree with the parser about it. Add a field to `Step` and
+either the schema moves or generation fails; there is no third outcome where
+the schema quietly describes last month's language.
 
 **What the schema can and cannot say.** Two limits are structural, not
 oversights, and both follow from the language's own design:
@@ -11,13 +13,12 @@ oversights, and both follow from the language's own design:
 *JSON has no YAML tags.* A validator sees a document after loading, so `!ii x`
 is invisible to it. The schema therefore describes the **desugared** projection
 (§6.1) — the shape `to_json` produces and the shape a YAML language server sees
-once wic tags are resolved.
+once Sophios tags are resolved.
 
 *Passthrough is open by definition.* The reference (§1) says anything outside
 the interpreted set is copied through untouched, so the schema cannot close any
-object that may carry passthrough CWL. It constrains the shapes the parser
-itself diagnoses — what `steps`, `in`, `out`, and `wic` must *be* — and admits
-anything else.
+object that may carry passthrough CWL. That openness is declared in the AST as
+`Shape.PASSTHROUGH`, not decided here.
 
 The result is a deliberate over-approximation: everything the parser accepts
 validates, and the structural mistakes the parser reports are rejected. It is
@@ -25,15 +26,41 @@ an editor aid, not a second implementation of the language.
 
 See docs/sophios_language_reference.md.
 """
+from dataclasses import fields
 from typing import Any, Final
 
+from .nodes import Document, OutputBinding, Shape, Step, WicSidecar, surface_of
 from .parser import DESUGARED_KEYS, INTERPRETED_STEP_KEYS, WIC_STEP_KEY_PATTERN
 
 #: Draft this schema targets. 2020-12 is what current editors consume.
 DIALECT: Final = 'https://json-schema.org/draft/2020-12/schema'
 
 #: Stable identifier, so an editor can bind it to `*.wic` by URI.
-SCHEMA_ID: Final = 'https://raw.githubusercontent.com/PolusAI/sophios/master/wic.schema.json'
+SCHEMA_ID: Final = 'https://raw.githubusercontent.com/PolusAI/sophios/master/sophios.schema.json'
+
+#: How each declared shape is expressed in JSON Schema. This is the only place
+#: that translates the AST's vocabulary into this format; the vocabulary itself
+#: belongs to `nodes.Shape`.
+_SHAPE_SCHEMA: Final[dict[Shape, dict[str, Any]]] = {
+    Shape.INPUT_BINDINGS: {
+        'description': 'Input bindings. Each input may be bound only once (§4.2).',
+        'type': 'object',
+        'additionalProperties': {'$ref': '#/$defs/inputValue'},
+    },
+    Shape.OUTPUT_BINDINGS: {
+        'type': 'array',
+        'items': {'$ref': '#/$defs/outputEntry'},
+    },
+    Shape.STEPS: {'$ref': '#/$defs/steps'},
+    Shape.SIDECAR: {'$ref': '#/$defs/wicBlock'},
+    Shape.SIDECAR_STEPS: {
+        'description': 'Per-step metadata, keyed "(index, name)".',
+        'type': 'object',
+        'patternProperties': {WIC_STEP_KEY_PATTERN: {'$ref': '#/$defs/wicBlock'}},
+        'additionalProperties': False,
+    },
+    Shape.IDENTITY: {'type': 'string', 'minLength': 1},
+}
 
 
 def wic_schema() -> dict[str, Any]:
@@ -42,24 +69,53 @@ def wic_schema() -> dict[str, Any]:
     Returned fresh each call: the result is mutable, and a shared instance a
     caller edited would corrupt every later export.
     """
+    document = _object_schema(Document)
     return {
         '$schema': DIALECT,
         '$id': SCHEMA_ID,
-        'title': 'Sophios .wic workflow',
-        'description': 'Desugared projection of a Sophios document. See docs/sophios_language_reference.md.',
-        'type': 'object',
-        'properties': {
-            'wic': _wic_block(),
-            'steps': {'$ref': '#/$defs/steps'},
-        },
-        # Open: every unlisted key is passthrough CWL by definition (§1).
-        'additionalProperties': True,
+        'title': 'Sophios workflow',
+        'description': 'Desugared projection of a Sophios document. '
+                       'See docs/sophios_language_reference.md.',
+        **document,
         '$defs': _defs(),
     }
 
 
+def _object_schema(node_type: type, *, omit: frozenset[str] = frozenset()) -> dict[str, Any]:
+    """Turn one AST node into a JSON Schema object, field by field.
+
+    Walks `dataclasses.fields` rather than a hand-written list, so a field
+    without a `Surface` declaration raises out of `surface_of` instead of being
+    quietly left out of the schema.
+    """
+    properties: dict[str, Any] = {}
+    open_object = False
+
+    for declared in fields(node_type):
+        form = surface_of(node_type, declared.name)
+        if declared.name in omit or form.shape is Shape.INTERNAL:
+            continue
+        match form.shape:
+            case Shape.PASSTHROUGH:
+                # Not a key: the licence for every key nobody else claimed.
+                open_object = True
+            case Shape.INTERPRETED:
+                # A closed set of CWL keys, listed for editor completion but
+                # left unconstrained — Sophios reads them, CWL owns their shapes.
+                for key in sorted(INTERPRETED_STEP_KEYS):
+                    properties[key] = {'description': f'Interpreted by Sophios: {key} (§4.3).'}
+            case _ if form.key is not None:
+                properties[form.key] = dict(_SHAPE_SCHEMA[form.shape])
+            case _:
+                # IDENTITY without a key is carried positionally, not as a key.
+                continue
+
+    return {'type': 'object', 'properties': properties, 'additionalProperties': open_object}
+
+
 def _defs() -> dict[str, Any]:
-    """The reusable shapes, one per construct the parser diagnoses."""
+    """The reusable shapes, each generated from the node it describes."""
+    step_body = _step_body()
     return {
         'steps': {
             'description': 'A mapping keyed by step name, or a sequence of steps.',
@@ -68,47 +124,51 @@ def _defs() -> dict[str, Any]:
                 {'type': 'array', 'items': {'$ref': '#/$defs/sequenceStep'}},
             ],
         },
-        'stepBody': _step_body(),
-        'sequenceStep': {
-            'description': "A step written in a sequence: either it carries id:, "
-                           "or it is a single-key mapping naming the step.",
-            'type': 'object',
-            'properties': {'id': {'type': 'string', 'minLength': 1}},
-            'additionalProperties': True,
-        },
+        'stepBody': step_body,
+        'sequenceStep': _sequence_step(),
         'inputValue': _input_value(),
         'construct': _construct(),
-        'outputEntry': {
-            'description': 'A bare output name, or a name bound to an edge definition.',
-            'oneOf': [
-                {'type': 'string'},
-                {'type': 'object', 'minProperties': 1, 'maxProperties': 1},
-            ],
-        },
+        'outputEntry': _output_entry(),
         'wicBlock': _wic_block(),
     }
 
 
 def _step_body() -> dict[str, Any]:
-    """A step's keys. Null is legal: a step may have no body at all (§3.1)."""
+    """A step keyed by name. Null is legal: a step may have no body (§3.1)."""
+    # `id` is omitted: in this form the step's name is the mapping key.
+    body = _object_schema(Step, omit=frozenset({'id'}))
+    return {**body, 'type': ['object', 'null']}
+
+
+def _sequence_step() -> dict[str, Any]:
+    """A step written in a sequence, which carries its own `id:`."""
+    body = _object_schema(Step)
     return {
+        **body,
+        'description': 'A step written in a sequence: either it carries id:, '
+                       'or it is a single-key mapping naming the step.',
+    }
+
+
+def _output_entry() -> dict[str, Any]:
+    """One `out:` entry: a bare name, or a name bound to an edge."""
+    identity = _SHAPE_SCHEMA[surface_of(OutputBinding, 'name').shape]
+    return {
+        'description': 'A bare output name, or a name bound to an edge definition.',
+        'oneOf': [
+            dict(identity),
+            {'type': 'object', 'minProperties': 1, 'maxProperties': 1},
+        ],
+    }
+
+
+def _wic_block() -> dict[str, Any]:
+    """The `wic:` sidecar. Null is legal: a bare `wic:` is empty (§5)."""
+    body = _object_schema(WicSidecar)
+    return {
+        **body,
+        'description': 'Compiler metadata. Never emitted to CWL (§5).',
         'type': ['object', 'null'],
-        'properties': {
-            'in': {
-                'description': 'Input bindings. Each input may be bound only once (§4.2).',
-                'type': 'object',
-                'additionalProperties': {'$ref': '#/$defs/inputValue'},
-            },
-            'out': {
-                'type': 'array',
-                'items': {'$ref': '#/$defs/outputEntry'},
-            },
-            # Listed for editor completion, not constrained: Sophios reads
-            # these but CWL owns their shapes.
-            **{key: {'description': f'Interpreted by Sophios: {key} (§4.3).'}
-               for key in sorted(INTERPRETED_STEP_KEYS)},
-        },
-        'additionalProperties': True,
     }
 
 
@@ -128,7 +188,7 @@ def _input_value() -> dict[str, Any]:
 
 
 def _construct() -> dict[str, Any]:
-    """A desugared wic construct: a single-key mapping.
+    """A desugared Sophios construct: a single-key mapping.
 
     Derived from the parser's dispatch table, so a construct added there
     appears here without anyone remembering to update a schema.
@@ -139,21 +199,4 @@ def _construct() -> dict[str, Any]:
         'maxProperties': 1,
         'properties': {key: {} for key in sorted(DESUGARED_KEYS)},
         'additionalProperties': False,
-    }
-
-
-def _wic_block() -> dict[str, Any]:
-    """The `wic:` sidecar. Null is legal: a bare `wic:` is an empty block (§5)."""
-    return {
-        'description': 'Compiler metadata. Never emitted to CWL (§5).',
-        'type': ['object', 'null'],
-        'properties': {
-            'steps': {
-                'description': 'Per-step metadata, keyed "(index, name)".',
-                'type': 'object',
-                'patternProperties': {WIC_STEP_KEY_PATTERN: {'$ref': '#/$defs/wicBlock'}},
-                'additionalProperties': False,
-            },
-        },
-        'additionalProperties': True,
     }

--- a/src/sophios/lang/schema.py
+++ b/src/sophios/lang/schema.py
@@ -27,21 +27,32 @@ an editor aid, not a second implementation of the language.
 See docs/sophios_language_reference.md.
 """
 from dataclasses import fields
-from typing import Any, Final
+from types import MappingProxyType
+from typing import Any, Final, Mapping, final
 
 from .nodes import Document, OutputBinding, Shape, Step, WicSidecar, surface_of
-from .parser import DESUGARED_KEYS, INTERPRETED_STEP_KEYS, WIC_STEP_KEY_PATTERN
+from .parser import Forms, Grammar
 
-#: Draft this schema targets. 2020-12 is what current editors consume.
-DIALECT: Final = 'https://json-schema.org/draft/2020-12/schema'
 
-#: Stable identifier, so an editor can bind it to `*.wic` by URI.
-SCHEMA_ID: Final = 'https://raw.githubusercontent.com/PolusAI/sophios/master/sophios.schema.json'
+@final
+class Json:  # pylint: disable=too-few-public-methods  # a namespace, not a type
+    """What this module needs to speak JSON Schema, and nothing more.
 
-#: How each declared shape is expressed in JSON Schema. This is the only place
-#: that translates the AST's vocabulary into this format; the vocabulary itself
-#: belongs to `nodes.Shape`.
-_SHAPE_SCHEMA: Final[dict[Shape, dict[str, Any]]] = {
+    The vocabulary being translated belongs to `nodes.Shape`; this namespace
+    holds only the target format's own constants.
+    """
+
+    #: Draft this schema targets. 2020-12 is what current editors consume.
+    DIALECT: Final = 'https://json-schema.org/draft/2020-12/schema'
+
+    #: Stable identifier, so an editor can bind it to `*.wic` by URI.
+    SCHEMA_ID: Final = 'https://raw.githubusercontent.com/PolusAI/sophios/master/sophios.schema.json'
+
+
+#: How each declared shape is expressed in JSON Schema. A read-only view of
+#: read-only fragments: callers get copies via `dict(...)` at use, so no caller
+#: can reach in and change what every later export produces.
+_SHAPE_SCHEMA: Final[Mapping[Shape, Mapping[str, Any]]] = MappingProxyType({
     Shape.INPUT_BINDINGS: {
         'description': 'Input bindings. Each input may be bound only once (§4.2).',
         'type': 'object',
@@ -56,11 +67,11 @@ _SHAPE_SCHEMA: Final[dict[Shape, dict[str, Any]]] = {
     Shape.SIDECAR_STEPS: {
         'description': 'Per-step metadata, keyed "(index, name)".',
         'type': 'object',
-        'patternProperties': {WIC_STEP_KEY_PATTERN: {'$ref': '#/$defs/wicBlock'}},
+        'patternProperties': {Grammar.WIC_STEP_KEY_PATTERN: {'$ref': '#/$defs/wicBlock'}},
         'additionalProperties': False,
     },
     Shape.IDENTITY: {'type': 'string', 'minLength': 1},
-}
+})
 
 
 def wic_schema() -> dict[str, Any]:
@@ -71,8 +82,8 @@ def wic_schema() -> dict[str, Any]:
     """
     document = _object_schema(Document)
     return {
-        '$schema': DIALECT,
-        '$id': SCHEMA_ID,
+        '$schema': Json.DIALECT,
+        '$id': Json.SCHEMA_ID,
         'title': 'Sophios workflow',
         'description': 'Desugared projection of a Sophios document. '
                        'See docs/sophios_language_reference.md.',
@@ -102,7 +113,7 @@ def _object_schema(node_type: type, *, omit: frozenset[str] = frozenset()) -> di
             case Shape.INTERPRETED:
                 # A closed set of CWL keys, listed for editor completion but
                 # left unconstrained — Sophios reads them, CWL owns their shapes.
-                for key in sorted(INTERPRETED_STEP_KEYS):
+                for key in sorted(Grammar.INTERPRETED_STEP_KEYS):
                     properties[key] = {'description': f'Interpreted by Sophios: {key} (§4.3).'}
             case _ if form.key is not None:
                 properties[form.key] = dict(_SHAPE_SCHEMA[form.shape])
@@ -197,6 +208,6 @@ def _construct() -> dict[str, Any]:
         'type': 'object',
         'minProperties': 1,
         'maxProperties': 1,
-        'properties': {key: {} for key in sorted(DESUGARED_KEYS)},
+        'properties': {key: {} for key in sorted(Forms.DESUGARED_KEYS)},
         'additionalProperties': False,
     }

--- a/src/sophios/utils_yaml.py
+++ b/src/sophios/utils_yaml.py
@@ -1,4 +1,6 @@
-from typing import Any
+"""The YAML tags Sophios owns, and the loader that understands them."""
+from types import MappingProxyType
+from typing import Any, Final, Mapping, final
 
 import yaml
 
@@ -7,28 +9,64 @@ import yaml
 # (i.e. the python api) cannot simply emit the dictionaries returned here,
 # because then these constructors will fire again.
 
-# Custom wic yaml tags (used when constructing yaml strings to feed back into wic_loader()).
-TAG_ANCHOR = '!&'
-TAG_ALIAS = '!*'
-TAG_INLINE_INPUT = '!ii'
 
-# The dict keys the tags above are rewritten to by the constructors below.
-# (Deliberately different from the tags themselves; see NOTE above.)
-KEY_ANCHOR = 'wic_anchor'
-KEY_ALIAS = 'wic_alias'
-KEY_INLINE_INPUT = 'wic_inline_input'
+@final
+class Tag:  # pylint: disable=too-few-public-methods  # a namespace, not a type
+    """The custom YAML tags Sophios owns.
+
+    A namespace rather than loose module constants: these four are one
+    vocabulary and are always reasoned about together, and grouping them keeps
+    `TAG_` prefixes from being the only thing relating them. Class attributes
+    are read-only in practice and shared safely across threads.
+    """
+
+    ANCHOR: Final = '!&'
+    ALIAS: Final = '!*'
+    INLINE_INPUT: Final = '!ii'
+    RAW_CWL: Final = '!cwl'
+
+    #: Every tag, for membership tests.
+    ALL: Final = frozenset({'!&', '!*', '!ii', '!cwl'})
+
+
+@final
+class Key:  # pylint: disable=too-few-public-methods  # a namespace, not a type
+    """The desugared spelling each tag is rewritten to.
+
+    Deliberately different from the tags themselves; see the NOTE above. A
+    constructor that re-emitted its own tag would fire again on reload, so the
+    loader would not be idempotent.
+    """
+
+    ANCHOR: Final = 'wic_anchor'
+    ALIAS: Final = 'wic_alias'
+    INLINE_INPUT: Final = 'wic_inline_input'
+    RAW_CWL: Final = 'wic_raw_cwl'
+
+    #: Every desugared key, for membership tests.
+    ALL: Final = frozenset({'wic_anchor', 'wic_alias', 'wic_inline_input', 'wic_raw_cwl'})
+
+
+#: Which tag desugars to which key. Read-only: a shared mapping that any
+#: caller could mutate is a race waiting to be found in production.
+TAG_TO_KEY: Final[Mapping[str, str]] = MappingProxyType({
+    Tag.ANCHOR: Key.ANCHOR,
+    Tag.ALIAS: Key.ALIAS,
+    Tag.INLINE_INPUT: Key.INLINE_INPUT,
+    Tag.RAW_CWL: Key.RAW_CWL,
+})
 
 
 def anchor_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> dict[str, Any]:
     """PyYAML constructor for the custom `!&` (wic anchor) tag."""
     val = loader.construct_scalar(node)
-    return {KEY_ANCHOR: val}
+    return {Key.ANCHOR: val}
 
 
 def alias_constructor(loader: yaml.SafeLoader, node: yaml.nodes.ScalarNode) -> dict[str, Any]:
     """PyYAML constructor for the custom `!*` (wic alias) tag."""
     val = loader.construct_scalar(node)
-    return {KEY_ALIAS: val}
+    return {Key.ALIAS: val}
 
 
 def inlineinput_constructor(loader: yaml.SafeLoader, node: yaml.nodes.Node) -> dict[str, dict[str, Any]]:
@@ -52,13 +90,33 @@ def inlineinput_constructor(loader: yaml.SafeLoader, node: yaml.nodes.Node) -> d
             val = loader.construct_sequence(node)
         case _:
             raise TypeError(f'Unknown yaml node type! {node}')
-    return {KEY_INLINE_INPUT: val}
+    return {Key.INLINE_INPUT: val}
+
+
+@final
+class WicLoader(yaml.SafeLoader):  # pylint: disable=too-many-ancestors  # SafeLoader's own depth
+    """A `SafeLoader` that understands the Sophios tags.
+
+    A subclass, not `yaml.SafeLoader` itself. Registering constructors on
+    `SafeLoader` changes how *every* `yaml.safe_load` in the process behaves —
+    including calls from unrelated libraries — for the rest of the program's
+    life, and mutates a class dictionary that other threads may be reading. The
+    subclass confines the tags to callers that ask for them.
+    """
+
+
+# Registered once, at import. Module import is serialised by the interpreter,
+# so this happens exactly once no matter how many threads reach it, and the
+# class is read-only afterwards.
+WicLoader.add_constructor(Tag.ANCHOR, anchor_constructor)
+WicLoader.add_constructor(Tag.ALIAS, alias_constructor)
+WicLoader.add_constructor(Tag.INLINE_INPUT, inlineinput_constructor)
 
 
 def wic_loader() -> type[yaml.SafeLoader]:
-    """Return a `yaml.SafeLoader` with the `!&`, `!*`, and `!ii` wic tags registered."""
-    loader = yaml.SafeLoader
-    loader.add_constructor(TAG_ANCHOR, anchor_constructor)
-    loader.add_constructor(TAG_ALIAS, alias_constructor)
-    loader.add_constructor(TAG_INLINE_INPUT, inlineinput_constructor)
-    return loader
+    """Return the loader that understands the Sophios tags.
+
+    Returns the same class every call. It carries no per-load state, so it is
+    safe to share across threads and processes.
+    """
+    return WicLoader

--- a/tests/core/test_lang_schema.py
+++ b/tests/core/test_lang_schema.py
@@ -26,7 +26,7 @@ import jsonschema
 import pytest
 from hypothesis import HealthCheck, given, settings
 
-from sophios.lang import DESUGARED_KEYS, INTERPRETED_STEP_KEYS, parse, to_json, wic_schema
+from sophios.lang import Forms, Grammar, parse, to_json, wic_schema
 from sophios.lang.nodes import (
     Document,
     EdgeDef,
@@ -42,7 +42,6 @@ from sophios.lang.nodes import (
     surface,
     surface_of,
 )
-from sophios.lang.parser import WIC_STEP_KEY_PATTERN
 
 from .test_lang_render import documents
 from .wic_corpus import CORPUS, corpus_id
@@ -78,13 +77,13 @@ def test_schema_is_derived_from_the_parser() -> None:
     without anyone remembering to edit it.
     """
     construct = SCHEMA['$defs']['construct']
-    assert set(construct['properties']) == set(DESUGARED_KEYS)
+    assert set(construct['properties']) == set(Forms.DESUGARED_KEYS)
 
     step_keys = set(SCHEMA['$defs']['stepBody']['properties'])
-    assert INTERPRETED_STEP_KEYS <= step_keys
+    assert Grammar.INTERPRETED_STEP_KEYS <= step_keys
 
     steps = SCHEMA['$defs']['wicBlock']['properties']['steps']
-    assert set(steps['patternProperties']) == {WIC_STEP_KEY_PATTERN}
+    assert set(steps['patternProperties']) == {Grammar.WIC_STEP_KEY_PATTERN}
 
 
 @pytest.mark.fast
@@ -154,7 +153,7 @@ def test_p09_rejects_what_the_parser_reports(label: str, source: str, projection
 
 
 @pytest.mark.fast
-@pytest.mark.parametrize('key', sorted(DESUGARED_KEYS))
+@pytest.mark.parametrize('key', sorted(Forms.DESUGARED_KEYS))
 def test_each_construct_validates(key: str) -> None:
     """Every desugared construct is accepted where an input value is expected."""
     assert _accepts({'steps': {'s': {'in': {'f': {key: 'x'}}}}})
@@ -225,7 +224,7 @@ def test_schema_keys_come_only_from_the_ast() -> None:
     the mapping key rather than a key inside it.
     """
     declared = {surface_of(Step, f.name).key for f in fields(Step)} - {None}
-    declared |= set(INTERPRETED_STEP_KEYS)
+    declared |= set(Grammar.INTERPRETED_STEP_KEYS)
 
     for form in ('sequenceStep', 'stepBody'):
         keys = set(SCHEMA['$defs'][form]['properties'])

--- a/tests/core/test_lang_schema.py
+++ b/tests/core/test_lang_schema.py
@@ -18,6 +18,7 @@ this here rather than asserting a stronger equivalence that is not true.
 
 See design_docs/core-refactor-design.md, Spec 1.
 """
+from dataclasses import dataclass, fields
 from pathlib import Path
 from typing import Any
 
@@ -26,6 +27,21 @@ import pytest
 from hypothesis import HealthCheck, given, settings
 
 from sophios.lang import DESUGARED_KEYS, INTERPRETED_STEP_KEYS, parse, to_json, wic_schema
+from sophios.lang.nodes import (
+    Document,
+    EdgeDef,
+    EdgeRef,
+    InlineLiteral,
+    OutputBinding,
+    RawCwlRef,
+    Shape,
+    Step,
+    StepKey,
+    UnresolvedName,
+    WicSidecar,
+    surface,
+    surface_of,
+)
 from sophios.lang.parser import WIC_STEP_KEY_PATTERN
 
 from .test_lang_render import documents
@@ -158,3 +174,83 @@ def test_a_step_may_have_no_body() -> None:
     """`some_subworkflow.wic:` with nothing under it is well-formed (§3.1)."""
     assert _accepts({'steps': {'sub.wic': None}})
     assert _accepts({'wic': None})
+
+# --------------------------------------------------------------------------
+# The AST is the source of truth
+# --------------------------------------------------------------------------
+#
+# The schema is generated from the `Surface` declarations in `nodes.py`. These
+# check that the generation is total — that no field can be added, and no key
+# invented, without one of these failing.
+
+
+AST_NODES = [Document, Step, OutputBinding, WicSidecar, StepKey,
+             InlineLiteral, EdgeDef, EdgeRef, RawCwlRef, UnresolvedName]
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('node_type', AST_NODES, ids=lambda n: n.__name__)
+def test_every_ast_field_declares_its_surface(node_type: type) -> None:
+    """Every field says how it is written, or `surface_of` raises.
+
+    A field with no declaration is a hole in the specification: the AST would
+    carry something the schema cannot describe and the reference does not
+    mention.
+    """
+    for declared in fields(node_type):
+        assert surface_of(node_type, declared.name) is not None
+
+
+@pytest.mark.fast
+def test_an_undeclared_field_is_rejected_loudly() -> None:
+    """Adding a field without declaring its surface fails, rather than
+    silently producing a schema that describes less than the AST holds."""
+
+    @dataclass(frozen=True)
+    class Drifted:
+        declared: str = surface(Shape.IDENTITY, 'declared')
+        forgotten: str = 'oops'
+
+    assert surface_of(Drifted, 'declared').key == 'declared'
+    with pytest.raises(TypeError, match='no surface declaration'):
+        surface_of(Drifted, 'forgotten')
+
+
+@pytest.mark.fast
+def test_schema_keys_come_only_from_the_ast() -> None:
+    """Every key the schema describes traces back to a declared field.
+
+    The schema is not allowed to invent syntax. `id` is expected on the
+    sequence form and absent from the mapping form, where the step's name is
+    the mapping key rather than a key inside it.
+    """
+    declared = {surface_of(Step, f.name).key for f in fields(Step)} - {None}
+    declared |= set(INTERPRETED_STEP_KEYS)
+
+    for form in ('sequenceStep', 'stepBody'):
+        keys = set(SCHEMA['$defs'][form]['properties'])
+        assert keys <= declared, f'{form} invented {keys - declared}'
+
+    assert 'id' in SCHEMA['$defs']['sequenceStep']['properties']
+    assert 'id' not in SCHEMA['$defs']['stepBody']['properties']
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('node_type,form', [(Step, 'sequenceStep'), (WicSidecar, 'wicBlock')],
+                         ids=['Step', 'WicSidecar'])
+def test_every_keyed_field_reaches_the_schema(node_type: type, form: str) -> None:
+    """A field that occupies a surface key is described by the schema."""
+    properties = SCHEMA['$defs'][form]['properties']
+    for declared in fields(node_type):
+        shape = surface_of(node_type, declared.name)
+        if shape.key is not None and shape.shape is not Shape.INTERNAL:
+            assert shape.key in properties, f'{node_type.__name__}.{declared.name} is not in the schema'
+
+
+@pytest.mark.fast
+def test_passthrough_declarations_open_their_objects() -> None:
+    """A node declaring PASSTHROUGH produces an open object, and one without
+    it does not. Openness is the AST's statement, not the generator's."""
+    assert any(surface_of(Step, f.name).shape is Shape.PASSTHROUGH for f in fields(Step))
+    assert SCHEMA['$defs']['sequenceStep']['additionalProperties'] is True
+    assert SCHEMA['$defs']['construct']['additionalProperties'] is False

--- a/tests/core/test_namespacing.py
+++ b/tests/core/test_namespacing.py
@@ -1,0 +1,123 @@
+"""The language layer's shared state is namespaced and safe to share.
+
+Two things are checked here, and neither is style:
+
+**Nothing leaks into a global.** `wic_loader()` used to register the Sophios
+tags on `yaml.SafeLoader` itself, which changed how every `yaml.safe_load` in
+the process behaved — including calls from libraries that had never heard of
+Sophios — for the rest of the program's life.
+
+**Shared tables cannot be mutated.** A module-level `dict` is reachable from
+every thread. One caller mutating it changes parsing for all of them, and the
+failure surfaces somewhere else entirely.
+
+Neither is caught by ordinary tests, because both are invisible until a second
+thread or a second library is involved.
+"""
+from concurrent.futures import ThreadPoolExecutor
+from types import MappingProxyType
+from typing import Any
+
+import pytest
+import yaml
+
+from sophios.lang import Forms, Grammar, parse, wic_schema
+from sophios.lang.render import render
+from sophios.utils_yaml import Key, Tag, WicLoader, wic_loader
+
+SOURCE = 'steps:\n- id: touch\n  in:\n    f: !ii empty.txt\n  out:\n  - file: !& out\n'
+
+
+# --------------------------------------------------------------------------
+# Nothing leaks into a global
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_the_loader_does_not_touch_the_global_safeloader() -> None:
+    """Using the Sophios loader leaves `yaml.safe_load` alone.
+
+    Registering on `yaml.SafeLoader` would make every later `safe_load` in the
+    process interpret `!ii`, anywhere, including in unrelated libraries.
+    """
+    yaml.load(SOURCE, Loader=wic_loader())
+
+    for tag in Tag.ALL:
+        assert tag not in yaml.SafeLoader.yaml_constructors, f'{tag} leaked onto SafeLoader'
+
+    with pytest.raises(yaml.YAMLError):
+        yaml.safe_load('x: !ii 5')
+
+
+@pytest.mark.fast
+def test_the_loader_is_a_subclass_not_safeloader_itself() -> None:
+    """The tags live on a dedicated class, so their scope is the callers who ask."""
+    assert wic_loader() is WicLoader
+    assert issubclass(WicLoader, yaml.SafeLoader)
+    assert WicLoader is not yaml.SafeLoader
+
+
+@pytest.mark.fast
+def test_the_loader_still_understands_every_tag() -> None:
+    """Isolation did not cost the tags themselves."""
+    loaded = yaml.load('a: !ii 5\nb: !& e\nc: !* e\n', Loader=wic_loader())
+    assert loaded == {'a': {Key.INLINE_INPUT: 5}, 'b': {Key.ANCHOR: 'e'}, 'c': {Key.ALIAS: 'e'}}
+
+
+# --------------------------------------------------------------------------
+# Shared tables cannot be mutated
+# --------------------------------------------------------------------------
+
+SHARED_MAPPINGS = [
+    ('Grammar.SCALAR_TAGS', Grammar.SCALAR_TAGS),
+    ('Forms.TAGGED', Forms.TAGGED),
+    ('Forms.DESUGARED', Forms.DESUGARED),
+]
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('name,mapping', SHARED_MAPPINGS, ids=[n for n, _ in SHARED_MAPPINGS])
+def test_shared_mappings_are_read_only(name: str, mapping: Any) -> None:
+    """A table every thread reads is one no thread can write."""
+    assert isinstance(mapping, MappingProxyType), f'{name} is a mutable mapping'
+    with pytest.raises(TypeError):
+        mapping['injected'] = None  # type: ignore[index]  # the point of the test
+
+
+@pytest.mark.fast
+def test_shared_sets_are_frozen() -> None:
+    """The same, for the sets."""
+    for shared in (Tag.ALL, Key.ALL, Grammar.INTERPRETED_STEP_KEYS, Forms.DESUGARED_KEYS):
+        assert isinstance(shared, frozenset)
+
+
+@pytest.mark.fast
+def test_the_exported_schema_is_not_shared() -> None:
+    """Each export is a fresh object, so one caller's edits cannot leak."""
+    first = wic_schema()
+    first['properties'].clear()
+    assert wic_schema()['properties']
+
+
+# --------------------------------------------------------------------------
+# Concurrent use
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_parsing_and_rendering_are_safe_from_many_threads() -> None:
+    """The same source parsed concurrently gives every thread the same answer.
+
+    Not a proof of thread safety — no test is — but it exercises the shared
+    tables, the loader, and the schema export from several threads at once,
+    which is where per-module mutable state would show up as divergence.
+    """
+    def once(_: int) -> tuple[str, int]:
+        document = parse(SOURCE, 'concurrent.wic').document
+        assert document is not None
+        return render(document), len(wic_schema()['$defs'])
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(once, range(64)))
+
+    assert len(set(results)) == 1, 'concurrent parses disagreed'


### PR DESCRIPTION
Stacks on #4 (`semrefac_3`); the two commits after its tip are this PR.

The first commit makes the JSON Schema genuinely generated from the AST instead of half-derived: the construct keys already came from the parser's tables, but the shape of a document — that `Step.inputs` is spelled `in:`, that `Step.outputs` is `out:`, that passthrough leaves an object open — was hand-written in `schema.py` to mirror `nodes.py`, two statements of one fact that nothing kept in agreement. Every AST field now declares its own surface form beside itself (`surface(Shape.INPUT_BINDINGS, 'in')`), the generator walks `dataclasses.fields`, and a field with no declaration stops generation rather than being quietly omitted. Adding a field either moves the schema or fails loudly; there is no third outcome where the schema describes last month's language. The reference's §6.3 now shows the same declarations it describes in English — one truth, stated once in prose and once in code, everything else downstream.

The second commit namespaces the language layer's shared state, and two of the findings were more than tidiness. `wic_loader()` registered its constructors on `yaml.SafeLoader` itself and returned it, which permanently changed how every `yaml.safe_load` in the process behaved — including calls from libraries that have never heard of Sophios — and mutated a class dictionary other threads may have been reading; it is now a dedicated `WicLoader` subclass, registered once at import. The parser's dispatch tables were plain module-level dicts any caller could mutate, changing how `!ii` parses process-wide with the failure surfacing somewhere else entirely; they are read-only `MappingProxyType` views now. Both behaviours are pinned by tests, including one that asserts `yaml.safe_load('x: !ii 5')` still raises — that the isolation holds — and one that parses and renders from eight threads and requires them to agree.
