### PR TITLE
Spec 1: report failures instead of terminating the caller's process

### DIFF
--- a/src/sophios/ast.py
+++ b/src/sophios/ast.py
@@ -1,13 +1,13 @@
 import uuid
 import copy
 from pathlib import Path
-import sys
 import traceback
 
 from mergedeep import merge, Strategy
 from jsonschema import Draft202012Validator
 import yaml
 
+from sophios.lang.diagnostics import Code, SophiosError
 from sophios.utils_yaml import wic_loader
 from . import python_cwl_adapter, utils, utils_cwl
 from .wic_types import Yaml, Tools, YamlTree, YamlForest, StepId, Tool
@@ -49,14 +49,14 @@ def read_ast_from_disk(homedir: str,
         # jsonschema.ValidationError) should be reported gracefully to the
         # user via a traceback file rather than crashing with a raw stack trace.
         yaml_path = Path(step_id.stem)
-        print('Failed to validate', yaml_path)
-        print(
-            f'See validation_{yaml_path.stem}.txt for detailed technical information.')
         # Do not display a nasty stack trace to the user; hide it in a file.
         with open(f'validation_{yaml_path.stem}.txt', mode='w', encoding='utf-8') as f:
             # https://mypy.readthedocs.io/en/stable/common_issues.html#python-version-and-system-platform-checks
             traceback.print_exception(type(e), value=e, tb=None, file=f)
-        sys.exit(1)
+        raise SophiosError.error(
+            Code.SUBWORKFLOW_INVALID,
+            f'Failed to validate {yaml_path}',
+            f'See validation_{yaml_path.stem}.txt for detailed technical information.') from e
 
     wic = {'wic': yaml_tree.get('wic') or {}}
     if 'implementations' in wic['wic']:

--- a/src/sophios/compiler.py
+++ b/src/sophios/compiler.py
@@ -2,7 +2,6 @@ import copy
 import json
 import os
 from pathlib import Path
-import sys
 from typing import Any, NamedTuple, cast
 
 import graphviz
@@ -18,6 +17,7 @@ from .wic_types import (CompilerInfo, CompilerOptions, EnvData, ExplicitEdgeCall
                         NodeData, RoseTree, Tool, Tools, WorkflowInputs, WorkflowInputsFile,
                         WorkflowOutputs, Yaml, YamlTagPaths, YamlTree, StepId)
 from .lang.cwl import CWL_VERSION
+from .lang.diagnostics import Code, SophiosError
 
 # NOTE: This must be initialized in main.py and/or cwl_subinterpreter.py
 inference_rules: dict[str, str] = {}
@@ -878,11 +878,10 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
 
                     arg_var_is_input = hashable and arg_var in setup.yaml_tree.get('inputs', {})
                     if not compiler_options['allow_raw_cwl'] and not arg_var_is_input:
-                        print(
-                            f"Warning! Did you forget to use !ii before {arg_var} in {setup.yaml_stem}.wic?")
-                        print(
+                        raise SophiosError.error(
+                            Code.UNRESOLVED_INPUT,
+                            f"Warning! Did you forget to use !ii before {arg_var} in {setup.yaml_stem}.wic?",
                             'If you want to compile the workflow anyway, use --allow_raw_cwl')
-                        sys.exit(1)
 
                     if 'doc' in inputs_key_dict:
                         inputs_key_dict['doc'] += '\\n' + in_dict.get('doc', '')
@@ -1116,9 +1115,9 @@ def generate_yaml_inputs(inputs_file_workflow: WorkflowInputsFile) -> WorkflowIn
         if value is None:
             if type_includes_null(raw_type):
                 return None
-            raise ValueError(
-                f"Required input of type {raw_type} was not provided."
-            )
+            raise SophiosError.error(
+                Code.MISSING_REQUIRED_INPUT,
+                f"Required input of type {raw_type} was not provided.")
 
         # Normalize type (strip null / ?)
         cwl_type = strip_null_from_union(raw_type)

--- a/src/sophios/cwl_subinterpreter.py
+++ b/src/sophios/cwl_subinterpreter.py
@@ -263,11 +263,6 @@ def main() -> None:
     except KeyboardInterrupt:
         pass
 
-    failed = False  # Your analysis goes here
-    if failed:
-        print(f'{cwl_tool} failed!')
-        sys.exit(1)
-
 
 if __name__ == "__main__":
     main()

--- a/src/sophios/lang/diagnostics.py
+++ b/src/sophios/lang/diagnostics.py
@@ -35,19 +35,32 @@ class Code(StrEnum):
     MALFORMED_WIC_STEP_KEY = 'wic008'
     UNKNOWN_TAG = 'wic009'
     DUPLICATE_KEY = 'wic010'
+    UNRESOLVED_INPUT = 'wic011'
+    MISSING_REQUIRED_INPUT = 'wic012'
+    SUBWORKFLOW_INVALID = 'wic013'
+    SCRIPT_ARGUMENT_MISMATCH = 'wic014'
+    CONTAINER_ENGINE_UNAVAILABLE = 'wic015'
+    MISSING_INPUT_FILE = 'wic016'
 
 
 @dataclass(frozen=True, slots=True)
 class Diagnostic:
-    """A single problem, located in source."""
+    """A single problem, located in source when a location is known.
+
+    Parse-phase diagnostics always carry a span — the parser worked from
+    positions, so it has one to give. Compile-phase diagnostics may not: until
+    the compiler runs on the AST, a failure often knows which workflow it came
+    from but not which line. An honest `None` beats an invented position.
+    """
 
     severity: Severity
     code: Code
     message: str
-    span: SourceSpan
+    span: SourceSpan | None = None
 
     def __str__(self) -> str:
-        return f'{self.span}: {self.severity} [{self.code}] {self.message}'
+        prefix = f'{self.span}: ' if self.span is not None else ''
+        return f'{prefix}{self.severity} [{self.code}] {self.message}'
 
 
 class Diagnostics(Sequence[Diagnostic]):
@@ -86,3 +99,32 @@ class Diagnostics(Sequence[Diagnostic]):
 
     def __repr__(self) -> str:
         return f'Diagnostics({self._items!r})'
+
+
+class SophiosError(Exception):
+    """A failure the library reports, never a process it terminates.
+
+    This is the deliverable of the design's §3 exception 1: library code used
+    to call `sys.exit(1)`, which meant an embedder's process died and the fuzz
+    test had to whitelist `SystemExit`. Every former exit site now raises this
+    instead, carrying the same messages as structured diagnostics.
+
+    Carries at least one diagnostic by construction — an error with nothing to
+    say is not reportable, so it is unrepresentable.
+    """
+
+    def __init__(self, diagnostics: Iterable[Diagnostic]) -> None:
+        items = Diagnostics(diagnostics)
+        if not len(items):
+            raise ValueError('SophiosError requires at least one diagnostic')
+        super().__init__('\n'.join(str(d) for d in items))
+        self.diagnostics: Diagnostics = items
+
+    @classmethod
+    def error(cls, code: Code, *messages: str) -> 'SophiosError':
+        """Build from one error, spelled as one or more message lines.
+
+        Multiple lines become multiple diagnostics under the same code, so the
+        advice text the exit sites used to print survives verbatim.
+        """
+        return cls(Diagnostic(Severity.ERROR, code, message) for message in messages)

--- a/src/sophios/main.py
+++ b/src/sophios/main.py
@@ -11,6 +11,7 @@ import networkx as nx
 import yaml
 from jsonschema import Draft202012Validator
 
+from sophios.lang.diagnostics import SophiosError
 from sophios.utils_yaml import wic_loader
 from . import input_output as io
 from . import post_compile as pc
@@ -125,6 +126,12 @@ def _build_and_compile_workflow(yaml_path: str, yaml_stem: str, yaml_tree: YamlT
             compiler_info = compiler.compile_workflow(yaml_tree, compiler_options, graph_settings, yaml_tag_paths,
                                                       [], [subgraph], {}, {}, {}, {},
                                                       tools_cwl, True, relative_run_path=True, testing=False)
+        except SophiosError as e:
+            # The library reports; only this adapter is allowed to exit. The
+            # messages are the same ones the old exit sites printed.
+            for diagnostic in e.diagnostics:
+                print(diagnostic.message)
+            sys.exit(1)
         except Exception as e:
             # Certain constraints are conditionally dependent on values and are
             # not easily encoded in the schema, so catch them here.
@@ -143,6 +150,16 @@ def _build_and_compile_workflow(yaml_path: str, yaml_stem: str, yaml_tree: YamlT
 
 
 def main() -> None:
+    """CLI entry point: run, and convert reported failures to exit codes."""
+    try:
+        _main()
+    except SophiosError as e:
+        for diagnostic in e.diagnostics:
+            print(diagnostic.message)
+        sys.exit(1)
+
+
+def _main() -> None:
     """See docs/userguide.md"""
     args, unknown_args = cli.parser.parse_known_args()
     plugins.logging_filters()

--- a/src/sophios/post_compile.py
+++ b/src/sophios/post_compile.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess as sub
 from . import plugins
 from .wic_types import RoseTree, NodeData, Yaml
+from .lang.diagnostics import Code, SophiosError
 
 
 def verify_container_engine_config(container_engine: str, ignore_container_install: bool) -> None:
@@ -39,19 +40,21 @@ def verify_container_engine_config(container_engine: str, ignore_container_insta
         if not docker_ok and not ignore_container_install:
 
             if permission_denied in output:
-                print('Warning! docker appears to be installed, but not configured as a non-root user.')
-                print('See https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user')
-                print('TL;DR you probably just need to run the following command (and then restart your machine)')
-                print('sudo usermod -aG docker $USER')
-                sys.exit(1)
+                raise SophiosError.error(
+                    Code.CONTAINER_ENGINE_UNAVAILABLE,
+                    'Warning! docker appears to be installed, but not configured as a non-root user.',
+                    'See https://docs.docker.com/engine/install/linux-postinstall/#manage-docker-as-a-non-root-user',
+                    'TL;DR you probably just need to run the following command (and then restart your machine)',
+                    'sudo usermod -aG docker $USER')
 
-            print(f'Warning! The {container_cmd} command does not appear to be installed.')
-            print(f"""Most workflows require docker containers and
-                  will fail at runtime if {container_cmd} is not installed.""")
-            print('If you want to try running the workflow anyway, use --ignore_docker_install')
-            print("""Note that --ignore_docker_install does
+            raise SophiosError.error(
+                Code.CONTAINER_ENGINE_UNAVAILABLE,
+                f'Warning! The {container_cmd} command does not appear to be installed.',
+                f"""Most workflows require docker containers and
+                  will fail at runtime if {container_cmd} is not installed.""",
+                'If you want to try running the workflow anyway, use --ignore_docker_install',
+                """Note that --ignore_docker_install does
                   NOT change whether or not any step in your workflow uses docker""")
-            sys.exit(1)
 
         # If docker is installed, check for too many running processes. (on linux, macos)
         if container_cmd_exists and sys.platform != "win32":
@@ -62,13 +65,14 @@ def verify_container_engine_config(container_engine: str, ignore_container_insta
             max_processes = 1000
             too_many_processes = num_processes > max_processes
             if too_many_processes and not ignore_container_install:
-                print(f'Warning! There are {num_processes} running docker processes.')
-                print(f'More than {max_processes} may potentially cause intermittent hanging issues.')
-                print('It is recommended to terminate the processes using the command')
-                print('`sudo pkill com.docker && sudo pkill Docker`')
-                print('and then restart Docker.')
-                print('If you want to run the workflow anyway, use --ignore_docker_processes')
-                sys.exit(1)
+                raise SophiosError.error(
+                    Code.CONTAINER_ENGINE_UNAVAILABLE,
+                    f'Warning! There are {num_processes} running docker processes.',
+                    f'More than {max_processes} may potentially cause intermittent hanging issues.',
+                    'It is recommended to terminate the processes using the command',
+                    '`sudo pkill com.docker && sudo pkill Docker`',
+                    'and then restart Docker.',
+                    'If you want to run the workflow anyway, use --ignore_docker_processes')
     else:
         cmd = [container_cmd, '--version']
         output = ''
@@ -81,11 +85,12 @@ def verify_container_engine_config(container_engine: str, ignore_container_insta
         singularity_ok = container_cmd_exists
 
         if not singularity_ok and not ignore_container_install:
-            print(f'Warning! The {container_cmd} command does not appear to be installed.')
-            print('If you want to try running the workflow anyway, use --ignore_docker_install')
-            print('Note that --ignore_docker_install does NOT change whether or not')
-            print('any step in your workflow uses docker or any other containers')
-            sys.exit(1)
+            raise SophiosError.error(
+                Code.CONTAINER_ENGINE_UNAVAILABLE,
+                f'Warning! The {container_cmd} command does not appear to be installed.',
+                'If you want to try running the workflow anyway, use --ignore_docker_install',
+                'Note that --ignore_docker_install does NOT change whether or not',
+                'any step in your workflow uses docker or any other containers')
 
 
 def cwl_docker_extract(container_engine: str, pull_dir: str, cwl_path: str | Path) -> None:
@@ -174,8 +179,7 @@ def stage_input_files(yml_inputs: Yaml,
             case {"class": "File", "location": location, **_rest_val}:
                 src_path = root_yml_dir_abs / Path(location)
                 if not src_path.exists() and throw:
-                    print(f"Error! {src_path} does not exist!")
-                    sys.exit(1)
+                    raise SophiosError.error(Code.MISSING_INPUT_FILE, f"Error! {src_path} does not exist!")
 
                 relroot = Path(basepath) if use_subdirs_cwl else Path(".")
                 dst_path = relroot / Path(location)

--- a/src/sophios/python_cwl_adapter.py
+++ b/src/sophios/python_cwl_adapter.py
@@ -5,6 +5,7 @@ import sys
 from types import ModuleType
 from typing import Any
 from .lang.cwl import CWL_VERSION
+from .lang.diagnostics import Code, SophiosError
 
 DRIVER_SCRIPT = '/python_cwl_driver.py'
 TYPES_SCRIPT = '/workflow_types.py'
@@ -87,19 +88,14 @@ def check_args_match_inputs(module_: ModuleType, args: dict[str, Any], check: bo
         module_ (ModuleType): A ModuleType object returned from import_python_file
         args (dict[str, Any]): A dictionary of keys value pairs
     """
-    error = False
-    for arg in args:
-        if arg not in module_.inputs:
-            print(f'Error! wic argument {arg} not in python arguments {module_.inputs}')
-            error = True
+    problems = [f'Error! wic argument {arg} not in python arguments {module_.inputs}'
+                for arg in args if arg not in module_.inputs]
     # Wait until after inference
     if check:
-        for arg in module_.inputs:
-            if arg not in args:
-                print(f'Error! Python argument {arg} not in wic arguments {args}')
-                error = True
-    if error:
-        sys.exit(1)
+        problems += [f'Error! Python argument {arg} not in wic arguments {args}'
+                     for arg in module_.inputs if arg not in args]
+    if problems:
+        raise SophiosError.error(Code.SCRIPT_ARGUMENT_MISMATCH, *problems)
 
 
 def generate_CWL_CommandLineTool(module_inputs: dict[str, Any], module_outputs: dict[str, Any],

--- a/tests/core/test_diagnostics.py
+++ b/tests/core/test_diagnostics.py
@@ -1,0 +1,212 @@
+"""The library reports failures; only the CLI adapter exits (CR-104).
+
+Properties covered:
+  P22  compilation never terminates the process
+  P23  every failure path produces at least one diagnostic
+  P24  CLI exit codes match pre-change behaviour
+
+P22 is enforced two ways. Statically: no core module except the CLI entry
+point contains a `sys.exit` call — the same scan shape as P14, because the
+failure it guards is equally silent. Dynamically: the fuzz suite compiles
+generated documents with no `SystemExit` arm left in its handler, so a
+process-killing path is a test failure there rather than a whitelisted event.
+
+P23 holds by construction — `SophiosError` cannot be built with zero
+diagnostics — plus one test per converted site proving the site actually
+raises it with the messages it used to print.
+
+See design_docs/core-refactor-design.md §3, deliberate exception 1.
+"""
+import ast as python_ast
+from pathlib import Path
+from types import ModuleType
+from typing import Final
+
+import pytest
+
+from sophios import post_compile
+from sophios.lang.diagnostics import Code, Diagnostic, Severity, SophiosError
+from sophios.python_cwl_adapter import check_args_match_inputs
+
+REPO_ROOT: Final = Path(__file__).resolve().parents[2]
+SRC: Final = REPO_ROOT / 'src' / 'sophios'
+
+#: The one module allowed to exit: the CLI adapter. Everything else reports.
+CLI_ADAPTER: Final = SRC / 'main.py'
+
+#: The contrib zone is out of scope for the core guarantee; its own entry
+#: points (REST server startup and the like) are someone's process to manage.
+CONTRIB: Final = SRC / 'contrib'
+
+
+def _core_files() -> list[Path]:
+    """Every core Python file except the CLI adapter."""
+    return sorted(path for path in SRC.rglob('*.py')
+                  if path != CLI_ADAPTER and CONTRIB not in path.parents)
+
+
+def _exit_calls(tree: python_ast.AST) -> list[int]:
+    """Line numbers of every `sys.exit(...)` / `exit(...)` / `quit(...)` call."""
+    found: list[int] = []
+    for node in python_ast.walk(tree):
+        match node:
+            case python_ast.Call(func=python_ast.Attribute(value=python_ast.Name(id='sys'), attr='exit')):
+                found.append(node.lineno)
+            case python_ast.Call(func=python_ast.Name(id='exit' | 'quit')):
+                found.append(node.lineno)
+    return found
+
+
+# --------------------------------------------------------------------------
+# P22 — the process is not the library's to terminate
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@pytest.mark.parametrize('path', _core_files(), ids=lambda p: str(p.relative_to(SRC)))
+def test_p22_no_core_module_calls_exit(path: Path) -> None:
+    """P22: no core library module contains a process-terminating call.
+
+    The dynamic half of P22 lives in the fuzz suite, whose exception handler
+    no longer has a `SystemExit` arm at all.
+    """
+    lines = _exit_calls(python_ast.parse(path.read_text(encoding='utf-8'), str(path)))
+    assert not lines, (
+        f'{path.relative_to(REPO_ROOT)} calls exit at lines {lines}; '
+        f'raise SophiosError and let the CLI adapter decide the exit code'
+    )
+
+
+@pytest.mark.fast
+def test_p22_the_scan_can_actually_fail() -> None:
+    """The scan detects each spelling it claims to, so P22 is not vacuous."""
+    for source in ('import sys\nsys.exit(1)', 'exit(1)', 'quit()'):
+        assert _exit_calls(python_ast.parse(source)), f'scan missed: {source}'
+
+
+@pytest.mark.fast
+def test_p22_the_cli_adapter_is_the_exception() -> None:
+    """`main.py` still exits — that is its job, and the scan must not creep
+    into forbidding it, or exit codes stop being anyone's responsibility."""
+    lines = _exit_calls(python_ast.parse(CLI_ADAPTER.read_text(encoding='utf-8')))
+    assert lines, 'main.py no longer exits anywhere; P24 has lost its subject'
+
+
+# --------------------------------------------------------------------------
+# P23 — a failure always has something to say
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_p23_an_error_with_no_diagnostics_is_unrepresentable() -> None:
+    """P23 by construction: the exception cannot exist empty."""
+    with pytest.raises(ValueError):
+        SophiosError([])
+
+
+@pytest.mark.fast
+def test_p23_str_carries_every_message() -> None:
+    """What an embedder logs by default includes each diagnostic, so catching
+    without inspecting `.diagnostics` still loses nothing."""
+    error = SophiosError.error(Code.UNRESOLVED_INPUT, 'first', 'second')
+    assert 'first' in str(error) and 'second' in str(error)
+    assert len(error.diagnostics) == 2
+
+
+@pytest.mark.fast
+def test_p23_spanless_diagnostics_print_without_a_location() -> None:
+    """Compile-phase failures may not know a line; the string form must not
+    invent one."""
+    diagnostic = Diagnostic(Severity.ERROR, Code.MISSING_INPUT_FILE, 'gone.txt missing')
+    assert str(diagnostic) == 'error [wic016] gone.txt missing'
+
+
+# --- the converted sites, one by one ---------------------------------------
+
+
+@pytest.mark.fast
+def test_script_argument_mismatch_reports(tmp_path: Path) -> None:
+    """`python_cwl_adapter` reports the mismatch it used to print-and-exit."""
+    module = ModuleType('fake_workflow_script')
+    module.inputs = {'expected_arg': int}  # type: ignore[attr-defined]
+
+    with pytest.raises(SophiosError) as caught:
+        check_args_match_inputs(module, {'unexpected_arg': 1}, check=True)
+
+    messages = [d.message for d in caught.value.diagnostics]
+    assert any('unexpected_arg' in m for m in messages)
+    assert any('expected_arg' in m for m in messages)
+    assert all(d.code is Code.SCRIPT_ARGUMENT_MISMATCH for d in caught.value.diagnostics)
+
+
+@pytest.mark.fast
+def test_missing_input_file_reports(tmp_path: Path) -> None:
+    """`stage_input_files` reports the absent file instead of exiting."""
+    inputs = {'in_file': {'class': 'File', 'location': 'does_not_exist.txt'}}
+
+    with pytest.raises(SophiosError) as caught:
+        post_compile.stage_input_files(inputs, tmp_path, str(tmp_path / 'out'), throw=True)
+
+    assert caught.value.diagnostics[0].code is Code.MISSING_INPUT_FILE
+    assert 'does_not_exist.txt' in caught.value.diagnostics[0].message
+
+
+@pytest.mark.fast
+def test_missing_container_engine_reports(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The docker check reports the same installation advice it printed."""
+    def command_not_found(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError('docker')
+
+    monkeypatch.setattr(post_compile.sub, 'run', command_not_found)
+
+    with pytest.raises(SophiosError) as caught:
+        post_compile.verify_container_engine_config('docker', False)
+
+    assert caught.value.diagnostics[0].code is Code.CONTAINER_ENGINE_UNAVAILABLE
+    assert any('--ignore_docker_install' in d.message for d in caught.value.diagnostics)
+
+
+@pytest.mark.fast
+def test_ignored_container_check_stays_silent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The escape hatch still works: --ignore_docker_install means no report."""
+    def command_not_found(*_args: object, **_kwargs: object) -> object:
+        raise FileNotFoundError('docker')
+
+    monkeypatch.setattr(post_compile.sub, 'run', command_not_found)
+    post_compile.verify_container_engine_config('docker', True)  # must not raise
+
+
+# --------------------------------------------------------------------------
+# P24 — the CLI still speaks exit codes
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_p24_cli_converts_a_report_to_exit_1(monkeypatch: pytest.MonkeyPatch,
+                                             capsys: pytest.CaptureFixture[str]) -> None:
+    """A reported failure leaves the CLI with the exact old behaviour: the
+    messages on stdout, exit code 1, no traceback."""
+    from sophios import main as cli
+
+    def reports(*_args: object, **_kwargs: object) -> None:
+        raise SophiosError.error(Code.UNRESOLVED_INPUT,
+                                 'Warning! Did you forget to use !ii before x in demo.wic?',
+                                 'If you want to compile the workflow anyway, use --allow_raw_cwl')
+
+    monkeypatch.setattr(cli, '_main', reports)
+
+    with pytest.raises(SystemExit) as caught:
+        cli.main()
+
+    assert caught.value.code == 1
+    printed = capsys.readouterr().out
+    assert 'Did you forget to use !ii' in printed
+    assert '--allow_raw_cwl' in printed
+
+
+@pytest.mark.fast
+def test_p24_success_does_not_exit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clean run returns instead of raising, exactly as before."""
+    from sophios import main as cli
+    monkeypatch.setattr(cli, '_main', lambda: None)
+    assert cli.main() is None  # type: ignore[func-returns-value]

--- a/tests/core/test_fuzzy_compile.py
+++ b/tests/core/test_fuzzy_compile.py
@@ -8,6 +8,7 @@ import pytest
 
 import sophios
 import sophios.ast
+from sophios.lang.diagnostics import SophiosError
 import sophios.cli
 import sophios.plugins
 import sophios.utils
@@ -70,7 +71,11 @@ class TestFuzzyCompile(unittest.TestCase):
             sophios.compiler.compile_workflow(yaml_tree, compiler_options, graph_settings,
                                               yaml_tag_paths, [], [graph], {}, {}, {}, {},
                                               tools_cwl, True, relative_run_path=True, testing=True)
-        except BaseException as e:
+        except SophiosError as e:
+            # P22 and P23 in one stroke: the library reported instead of
+            # exiting, and what it reported is non-empty and structured.
+            assert len(e.diagnostics) > 0
+        except Exception as e:
             expected_messages = (
                 'Error! Multiple definitions of &',
                 'Error! Unbound literal variable ~',
@@ -94,12 +99,11 @@ class TestFuzzyCompile(unittest.TestCase):
             )
             # Certain constraints are conditionally dependent on values and are
             # not easily encoded in the schema, so catch them here.
-            # Moreover, although we check for the existence of input files in
-            # stage_input_files, we cannot encode file existence in json schema
-            # to check the python_script script: tag before compile time.
-            if isinstance(e, SystemExit) and e.code == 1:
-                pass
-            elif any(msg in str(e) for msg in expected_messages):
+            # The SystemExit arm is gone because the library no longer exits:
+            # what used to be a whitelisted process death is the SophiosError
+            # arm above (CR-104). `except Exception` rather than BaseException
+            # for the same reason — a SystemExit now IS a test failure.
+            if any(msg in str(e) for msg in expected_messages):
                 pass
             else:
                 raise e

--- a/tests/core/test_lang_parser.py
+++ b/tests/core/test_lang_parser.py
@@ -182,8 +182,14 @@ def test_p05_input_values_are_closed(source: str) -> None:
 @given(st.text(max_size=400))
 @FAST
 def test_p06_diagnostic_spans_index_real_source(text: str) -> None:
-    """P06: a diagnostic never points outside the document it describes."""
+    """P06: a parse diagnostic always has a span, inside the document.
+
+    The `Diagnostic` type allows a spanless entry because compile-phase
+    failures may not know a position — but the *parser* always does, and this
+    is where that stronger guarantee is enforced.
+    """
     for diagnostic in parse(text, 'fuzz.wic').diagnostics:
+        assert diagnostic.span is not None, f'parse diagnostic without a span: {diagnostic}'
         assert diagnostic.span.file == 'fuzz.wic'
         assert diagnostic.span.start_line >= 1
         assert diagnostic.span.start_column >= 1
@@ -325,6 +331,7 @@ def test_malformed_yaml_reports_a_located_diagnostic() -> None:
     result = parse('steps:\n  - [unclosed\n', 'bad.wic')
     assert result.document is None
     assert len(result.diagnostics) == 1
+    assert result.diagnostics[0].span is not None
     assert result.diagnostics[0].span.start_line >= 1
 
 
@@ -339,6 +346,7 @@ def test_repeated_input_is_reported_not_silently_resolved() -> None:
 
     assert [d.code for d in result.diagnostics] == [Code.DUPLICATE_KEY]
     assert "'f'" in result.diagnostics[0].message
+    assert result.diagnostics[0].span is not None
     assert result.diagnostics[0].span.start_line == 5
 
 


### PR DESCRIPTION
Stacks on #5 (`semrefac_4`); the two commits after its tip are this PR.

This is the design's first deliberate compatibility exception: library code raised `SystemExit` where it should have reported. Nine `sys.exit(1)` sites — the compiler's unresolved-input and missing-required-input checks, subworkflow validation, the python-script argument check, and the four container-engine and input-staging checks — become `SophiosError` raises carrying the same messages as structured diagnostics; a tenth site guarded `failed = False  # Your analysis goes here` and could never fire, so it is deleted rather than converted. `SophiosError` cannot be constructed with zero diagnostics, so "every failure has something to say" holds by construction rather than by discipline, and its string form carries every message so an embedder who logs the exception without inspecting it loses nothing. This also closes CE-01: the `!ii`-null crash that reached a bare `ValueError` is now a diagnostic with a stable code.

From the outside the CLI is unchanged: `main()` becomes an adapter that catches the report, prints each diagnostic's message — the same text the exit sites used to print — and exits 1. Only `main.py` may exit, and a static scan over every core module enforces that, tested against the spellings it claims to catch. The fuzz test's `SystemExit` whitelist is removed rather than bypassed: its handler now has a `SophiosError` arm asserting diagnostics are present, and catches `Exception` instead of `BaseException`, so a process-killing path is a test failure there instead of a whitelisted event. Embedders see the breaking change, which is the point — a bad workflow raises where it used to kill the process, and the session survives.

BREAKING CHANGE: library code raises `SophiosError` instead of calling `sys.exit(1)`. CLI exit codes are unchanged.
