### PR TITLE
Spec 1: resolve, surface, and override the language version

### DIFF
--- a/docs/sophios_language_reference.md
+++ b/docs/sophios_language_reference.md
@@ -34,13 +34,13 @@ yet wired into the compiler**, and are marked where they appear:
 
 | Construct | Specified | Accepted by `sophios.lang` | Usable in a compiled workflow |
 |---|---|---|---|
-| `!cwl` raw CWL reference (§4.1) | Yes | Yes | **Not yet** — CR-104 |
-| `lang_version` resolution (§7) | Yes | — | **Not yet** — CR-103 |
+| `!cwl` raw CWL reference (§4.1) | Yes | Yes | **Not yet** — Spec 3 migration |
 
 Everything else describes what Sophios does today. Writing `!cwl` in a `.wic`
-file will not work until CR-104 lands, because the loader the compiler uses does
-not yet know the tag. It is documented now because the specification is what
-the implementation is being built against, not a record written afterwards.
+file will not work until the compiler runs on the `sophios.lang` parser (the
+Spec 3 migration), because the loader it uses today does not know the tag. It
+is documented now because the specification is what the implementation is
+being built against, not a record written afterwards.
 
 ---
 
@@ -337,11 +337,6 @@ without the right plugins installed. That is not a language error.
 
 ## 7. Versioning
 
-> **Not yet implemented.** This section specifies how versioning will behave;
-> `lang_version` is not read or reported by any code path today. Tracked as
-> CR-103. Until it lands, every file is compiled by the one implementation that
-> exists, and no tag has any effect.
-
 `lang_version` starts at **0.0.1**, defined against CWL v1.2. The Sophios
 version and its CWL substrate move together.
 
@@ -358,6 +353,10 @@ compiles — not merely the newest version available. That means:
 You need a tag only to pin a file for reproducibility, or where a construct is
 valid under two versions with different meanings.
 
-The version Sophios chose will always be reported — on the command line, on
-`CompiledWorkflow`, and as an annotation in the emitted CWL. You should never
-have to guess which language your file was read as.
+The version Sophios chose is always reported — on the command line, on
+`CompiledWorkflow.lang_version`, and as a `sophios:lang_version` annotation in
+the emitted CWL, namespaced so the output stays valid. It can be pinned per
+file (`wic: {lang_version: 0.0.1}`) or set for a whole compilation with
+`--lang_version` / `Workflow.compile(lang_version=...)`; the explicit setting
+beats any tag, and one compilation resolves to exactly one version tree-wide.
+You should never have to guess which language your file was read as.

--- a/src/sophios/api/python/_compiled.py
+++ b/src/sophios/api/python/_compiled.py
@@ -38,6 +38,8 @@ class CompiledWorkflow:
     name: str
     cwl_workflow: Json
     cwl_job_inputs: Json
+    #: The Sophios language version this workflow was compiled under.
+    lang_version: str = ''
 
     def to_cwl_yaml(self) -> str:
         """Return the compiled CWL workflow as YAML."""

--- a/src/sophios/api/python/_workflow_runtime.py
+++ b/src/sophios/api/python/_workflow_runtime.py
@@ -19,6 +19,7 @@ from cwl_utils.parser import CommandLineTool as CWLCommandLineTool
 from cwl_utils.parser import load_document_by_uri, load_document_by_yaml
 
 from sophios import compiler, input_output, plugins, post_compile as pc, run_local as rl
+from sophios.lang import versions
 from sophios.input_output import dump_wic_yaml as _dump_yaml
 from sophios.cli import get_dicts_for_compilation, get_known_and_unknown_args
 from sophios.runtime_inputs import normalize_rose_tree_cwl, normalize_rose_tree_job_inputs
@@ -446,6 +447,7 @@ def compile_workflow(
     *,
     write_to_disk: bool = False,
     tool_registry: Tools | None = None,
+    lang_version: str | None = None,
 ) -> CompilerInfo:
     """Compile a Python API workflow into CWL.
 
@@ -467,6 +469,8 @@ def compile_workflow(
     merged_tools = _merged_known_tools(workflow._flatten_steps(), tool_registry)
 
     compiler_options, graph_settings, yaml_tag_paths = get_dicts_for_compilation()
+    if lang_version is not None:
+        compiler_options = {**compiler_options, 'lang_version': lang_version}
     compiler_info = compiler.compile_workflow(
         yaml_tree,
         compiler_options,
@@ -522,6 +526,7 @@ def compiled_workflow_from_compiler_info(
         name=workflow.process_name,
         cwl_workflow=cwl_workflow,
         cwl_job_inputs=normalize_rose_tree_job_inputs(rose_tree, sub_node_data.workflow_inputs_file),
+        lang_version=str(cwl_workflow.get(versions.ANNOTATION_KEY, versions.LANG_VERSION)),
     )
 
 
@@ -529,12 +534,15 @@ def compiled_workflow(
     workflow: "Workflow",
     *,
     tool_registry: Tools | None = None,
+    lang_version: str | None = None,
 ) -> CompiledWorkflow:
     """Compile a workflow into the public compiled-workflow boundary object.
 
     Args:
         workflow (Workflow): Workflow to compile.
         tool_registry (Tools | None): Optional tool registry override.
+        lang_version (str | None): Pin the Sophios language version for this
+            compilation; None infers it. An explicit setting beats file tags.
 
     Returns:
         CompiledWorkflow: Compiled CWL workflow plus generated job inputs.
@@ -542,6 +550,7 @@ def compiled_workflow(
     compiler_info = compile_workflow(
         workflow,
         tool_registry=tool_registry,
+        lang_version=lang_version,
     )
     return compiled_workflow_from_compiler_info(workflow, compiler_info)
 

--- a/src/sophios/api/python/workflow.py
+++ b/src/sophios/api/python/workflow.py
@@ -907,6 +907,7 @@ class Workflow(_ProcessBase):
         self,
         *,
         tool_registry: Tools | None = None,
+        lang_version: str | None = None,
     ) -> CompiledWorkflow:
         """Compile this workflow into CWL and generated job inputs.
 
@@ -915,11 +916,15 @@ class Workflow(_ProcessBase):
 
         Args:
             tool_registry (Tools | None): Optional tool registry override.
+            lang_version (str | None): Pin the Sophios language version for
+                this compilation; None (the default) infers it. An explicit
+                setting beats any file tag. The resolved version is reported
+                on the result as ``CompiledWorkflow.lang_version``.
 
         Returns:
             CompiledWorkflow: Public compiled workflow boundary object.
         """
-        return _compiled_workflow(self, tool_registry=tool_registry)
+        return _compiled_workflow(self, tool_registry=tool_registry, lang_version=lang_version)
 
     def run(
         self,

--- a/src/sophios/cli.py
+++ b/src/sophios/cli.py
@@ -51,6 +51,9 @@ parser.add_argument('--quiet', default=False, action="store_true",
                     and it will capture all stdout/stderr into log files for each step.''')
 parser.add_argument('--cwl_runner', type=str, required=False, default='cwltool', choices=['cwltool', 'toil-cwl-runner'],
                     help='The CWL runner to use for running workflows locally.')
+parser.add_argument('--lang_version', type=str, default=None,
+                    help='Pin the Sophios language version for this compilation. '
+                    'Defaults to inferring the newest version that accepts the source.')
 parser.add_argument('--allow_raw_cwl', default=False, action="store_true",
                     help='Do not check whether the input to a workflow step refers to the workflow inputs: tag')
 parser.add_argument('--ignore_docker_install', default=False, action="store_true",
@@ -176,6 +179,7 @@ def get_dicts_for_compilation() -> tuple[CompilerOptions, GraphSettings, YamlTag
         'insert_steps_automatically': args.insert_steps_automatically,
         'inference_disable': args.inference_disable,
         'allow_raw_cwl': args.allow_raw_cwl,
+        'lang_version': args.lang_version,
     }
 
     # to be given to graph util functions

--- a/src/sophios/compiler.py
+++ b/src/sophios/compiler.py
@@ -16,6 +16,7 @@ from .wic_types import (CompilerInfo, CompilerOptions, EnvData, ExplicitEdgeCall
                         ExplicitEdgeDefs, GraphData, GraphReps, GraphSettings, Namespaces,
                         NodeData, RoseTree, Tool, Tools, WorkflowInputs, WorkflowInputsFile,
                         WorkflowOutputs, Yaml, YamlTagPaths, YamlTree, StepId)
+from .lang import versions
 from .lang.cwl import CWL_VERSION
 from .lang.diagnostics import Code, SophiosError
 
@@ -262,6 +263,7 @@ def _prepare_compilation_state(yaml_tree_ast: YamlTree,
 
 
 def _finalize_compilation(*,
+                          lang_version: str,
                           wic: Yaml,
                           namespaces: Namespaces,
                           yaml_stem: str,
@@ -322,6 +324,13 @@ def _finalize_compilation(*,
 
     vars_workflow_output_internal = list(
         set(vars_workflow_output_internal))  # Get uniques
+    # Surface the resolved language version in the emitted artifact, as a
+    # declared extension field so the output remains valid CWL v1.2. Like the
+    # edam binding above, the `sophios` namespace prefix is reserved.
+    yaml_tree['$namespaces'] = {**yaml_tree.get('$namespaces', {}),
+                                versions.ANNOTATION_NAMESPACE: versions.ANNOTATION_NAMESPACE_URI}
+    yaml_tree[versions.ANNOTATION_KEY] = lang_version
+
     workflow_outputs = utils_cwl.get_workflow_outputs(graph_settings, namespaces, is_root, yaml_stem,
                                                       steps, outputs_workflow, vars_workflow_output_internal,
                                                       graph, tools_lst, step_node_name, tools)
@@ -364,6 +373,26 @@ def _finalize_compilation(*,
                        explicit_edge_defs_copy, explicit_edge_calls_copy)
     compiler_info = CompilerInfo(rose_tree, env_data)
     return compiler_info
+
+
+def _lang_version_pins(node: Any) -> tuple[str, ...]:
+    """Collect every `wic: lang_version:` tag reachable in a merged tree.
+
+    The merged AST inlines subworkflows, so walking the root tree sees every
+    file's tag and a conflict anywhere in the tree is caught at the root.
+    """
+    pins: list[str] = []
+    match node:
+        case {'wic': {'lang_version': str() as pin}, **_rest}:
+            pins.append(pin)
+    match node:
+        case dict():
+            for value in node.values():
+                pins.extend(_lang_version_pins(value))
+        case list():
+            for value in node:
+                pins.extend(_lang_version_pins(value))
+    return tuple(pins)
 
 
 def compile_workflow_once(yaml_tree_ast: YamlTree,
@@ -410,6 +439,14 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
         (in the Rose Tree) together with mutable cumulative environment\n
         information which needs to be passed through the recursion.
     """
+    lang_version = versions.resolve(compiler_options.get('lang_version'))
+    if is_root:
+        # Resolution happens once, from the whole merged tree; subworkflow
+        # compilations inherit the result below, so one compilation yields
+        # exactly one version tree-wide no matter how subtrees are tagged.
+        lang_version = versions.resolve(compiler_options.get('lang_version'),
+                                        _lang_version_pins(yaml_tree_ast.yml))
+
     setup = _prepare_compilation_state(yaml_tree_ast, namespaces, subgraphs, explicit_edge_defs,
                                        explicit_edge_calls, input_mapping, output_mapping, testing)
     # NOTE: graphdata and vars_workflow_output_internal are kept as local aliases (rather than
@@ -455,7 +492,8 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
             graphdata = GraphData(step_key)
             subgraph = GraphReps(subgraph_gv, subgraph_nx, graphdata)
 
-            sub_compiler_info = compile_workflow(sub_yaml_tree, compiler_options, graph_settings, yaml_tag_paths,
+            sub_options: CompilerOptions = {**compiler_options, 'lang_version': lang_version}
+            sub_compiler_info = compile_workflow(sub_yaml_tree, sub_options, graph_settings, yaml_tag_paths,
                                                  namespaces +
                                                  [step_name_or_key], subgraphs +
                                                  [subgraph],
@@ -1031,6 +1069,7 @@ def compile_workflow_once(yaml_tree_ast: YamlTree,
                 setup.steps[i]['when'] = f"$({when_clause})"
 
     return _finalize_compilation(
+        lang_version=lang_version,
         wic=setup.wic, namespaces=namespaces, yaml_stem=setup.yaml_stem, graph_settings=graph_settings,
         graph=setup.graph, sibling_subgraphs=setup.sibling_subgraphs, step_1_names=setup.step_1_names,
         steps_keys=setup.steps_keys, subkeys=setup.subkeys, yaml_tree=setup.yaml_tree,

--- a/src/sophios/lang/__init__.py
+++ b/src/sophios/lang/__init__.py
@@ -29,6 +29,7 @@ from .nodes import (
 from ..utils_yaml import Key, Tag
 from .parser import Forms, Grammar, ParseResult, parse
 from .render import render, to_json
+from .versions import KNOWN_VERSIONS, LANG_VERSION, resolve as resolve_lang_version
 from .schema import wic_schema
 from .spans import SourceSpan
 
@@ -39,6 +40,7 @@ __all__ = [
     'Code',
     'Diagnostic',
     'Diagnostics',
+    'KNOWN_VERSIONS',
     'Key',
     'Document',
     'Forms',
@@ -47,6 +49,7 @@ __all__ = [
     'EdgeRef',
     'InlineLiteral',
     'InputValue',
+    'LANG_VERSION',
     'OpaqueCwl',
     'OutputBinding',
     'ParseResult',
@@ -60,6 +63,7 @@ __all__ = [
     'WicSidecar',
     'parse',
     'render',
+    'resolve_lang_version',
     'to_json',
     'wic_schema',
 ]

--- a/src/sophios/lang/diagnostics.py
+++ b/src/sophios/lang/diagnostics.py
@@ -41,6 +41,8 @@ class Code(StrEnum):
     SCRIPT_ARGUMENT_MISMATCH = 'wic014'
     CONTAINER_ENGINE_UNAVAILABLE = 'wic015'
     MISSING_INPUT_FILE = 'wic016'
+    UNKNOWN_LANG_VERSION = 'wic017'
+    LANG_VERSION_CONFLICT = 'wic018'
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/sophios/lang/versions.py
+++ b/src/sophios/lang/versions.py
@@ -1,0 +1,74 @@
+"""The Sophios language version: what exists, and how one is chosen.
+
+The reference (§7) defines the scheme: `lang_version` starts at 0.0.1, the tag
+is optional and expected to stay unused, and an untagged file is compiled at
+the highest version under which its source actually compiles. Today exactly
+one version exists, so resolution always lands on 0.0.1 — but the *mechanism*
+is written for the general case and property-tested with fabricated version
+lists, because the first real version bump is precisely when nobody will want
+to discover the resolver was a stub.
+
+Selection precedence (§5.8 of the design):
+
+    1. an explicit setting — the `--lang_version` flag or API parameter
+    2. per-file `lang_version` tags, which are exact pins
+    3. the newest version that satisfies everything, which for untagged
+       trees is simply the newest version
+
+One compilation resolves to exactly one version, tree-wide. Conflicting exact
+pins therefore cannot be satisfied and are reported, not averaged.
+"""
+from typing import Final
+
+from .diagnostics import Code, SophiosError
+
+#: Every version that has ever existed, oldest first. Append-only.
+KNOWN_VERSIONS: Final[tuple[str, ...]] = ('0.0.1',)
+
+#: The newest version — what untagged sources resolve to.
+LANG_VERSION: Final[str] = KNOWN_VERSIONS[-1]
+
+#: The namespace under which the resolved version is annotated in emitted CWL,
+#: so the annotation is a declared extension field and the output stays valid.
+ANNOTATION_NAMESPACE: Final[str] = 'sophios'
+ANNOTATION_NAMESPACE_URI: Final[str] = 'https://github.com/PolusAI/sophios#'
+ANNOTATION_KEY: Final[str] = f'{ANNOTATION_NAMESPACE}:lang_version'
+
+
+def resolve(requested: str | None = None,
+            pins: tuple[str, ...] = (),
+            *,
+            known: tuple[str, ...] = KNOWN_VERSIONS) -> str:
+    """Choose the one version this compilation runs under.
+
+    `requested` is the explicit setting and always wins when given; asking for
+    a version that does not exist is reported, never coerced. `pins` are the
+    per-file tags found in the tree — exact pins, so more than one distinct
+    pin is a conflict. With neither, the newest known version is chosen: never
+    silently anything lower.
+
+    `known` exists so the mechanism can be tested against fabricated version
+    histories; production callers never pass it.
+    """
+    if requested is not None:
+        if requested not in known:
+            raise SophiosError.error(
+                Code.UNKNOWN_LANG_VERSION,
+                f'Unknown lang_version {requested!r}. Known versions: {", ".join(known)}')
+        return requested
+
+    distinct = sorted(set(pins), key=known.index) if set(pins) <= set(known) else None
+    if distinct is None:
+        bad = sorted(set(pins) - set(known))
+        raise SophiosError.error(
+            Code.UNKNOWN_LANG_VERSION,
+            f'Unknown lang_version tag(s) {", ".join(map(repr, bad))}. Known versions: {", ".join(known)}')
+    if len(distinct) > 1:
+        raise SophiosError.error(
+            Code.LANG_VERSION_CONFLICT,
+            f'One compilation resolves to one version, but the tree pins {", ".join(distinct)}.',
+            'Remove the conflicting lang_version tags, or set one explicitly to override them all.')
+    if distinct:
+        return distinct[0]
+
+    return known[-1]

--- a/src/sophios/main.py
+++ b/src/sophios/main.py
@@ -11,6 +11,7 @@ import networkx as nx
 import yaml
 from jsonschema import Draft202012Validator
 
+from sophios.lang import versions
 from sophios.lang.diagnostics import SophiosError
 from sophios.utils_yaml import wic_loader
 from . import input_output as io
@@ -146,6 +147,10 @@ def _build_and_compile_workflow(yaml_path: str, yaml_stem: str, yaml_tree: YamlT
                 traceback.print_exception(type(e), value=e, tb=None, file=f)
             sys.exit(1)
         rose_tree = compiler_info.rose
+        # P18: the resolved language version is reported on every compile,
+        # not only on failure — nobody should have to guess which language
+        # their file was read as.
+        print('Sophios lang_version:', rose_tree.data.compiled_cwl.get(versions.ANNOTATION_KEY))
     return rootgraph, rose_tree
 
 

--- a/src/sophios/wic_types.py
+++ b/src/sophios/wic_types.py
@@ -1,4 +1,4 @@
-from typing import Any, NamedTuple, TypeAlias, TypedDict
+from typing import Any, NamedTuple, NotRequired, TypeAlias, TypedDict
 
 import networkx as nx
 
@@ -151,6 +151,9 @@ class CompilerOptions(TypedDict):
     insert_steps_automatically: bool
     inference_disable: bool
     allow_raw_cwl: bool
+    #: The explicit language version, if the user set one; None means infer.
+    #: NotRequired so existing constructors of this dict stay valid.
+    lang_version: NotRequired[str | None]
 
 
 class GraphSettings(TypedDict):

--- a/tests/core/test_lang_version.py
+++ b/tests/core/test_lang_version.py
@@ -1,0 +1,221 @@
+"""Language-version resolution, surfacing, and override (CR-103).
+
+Properties covered:
+  P15  the resolved version is the highest that satisfies the source
+  P16  no lower version is ever silently selected
+  P17  untagged files resolve rather than fail
+  P18  every successful compile reports a resolved version
+  P19  the artifact annotation is present and keeps the CWL valid
+  P20  an explicit setting always beats a file tag
+  P21  one compilation yields exactly one version, tree-wide
+
+Exactly one version exists today, so resolution against the real version list
+always lands on 0.0.1. The *mechanism* is therefore tested against fabricated
+version histories as well — the first real version bump is exactly when nobody
+will want to discover the resolver was a stub that worked by coincidence.
+"""
+from pathlib import Path
+import graphviz
+import networkx as nx
+import pytest
+import yaml
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+import sophios.cli
+import sophios.compiler
+import sophios.post_compile
+from sophios.lang import KNOWN_VERSIONS, LANG_VERSION, resolve_lang_version
+from sophios.lang.diagnostics import Code, SophiosError
+from sophios.lang.versions import ANNOTATION_KEY, ANNOTATION_NAMESPACE, ANNOTATION_NAMESPACE_URI
+from sophios.wic_types import GraphData, GraphReps, StepId, Yaml, YamlTree
+
+from .test_setup import tools_cwl
+
+FAST = settings(max_examples=200, suppress_health_check=[HealthCheck.too_slow], deadline=None)
+
+#: Fabricated, ordered version histories: what the resolver will face someday.
+histories = st.lists(
+    st.integers(min_value=0, max_value=40).map(lambda n: f'0.0.{n}'),
+    min_size=1, max_size=6, unique=True,
+).map(lambda vs: tuple(sorted(vs, key=lambda v: int(v.rsplit('.', 1)[1]))))
+
+
+def _compile(yml: Yaml, lang_version: str | None = None) -> Yaml:
+    """Compile one in-memory workflow and return the emitted CWL."""
+    options, graph_settings, tag_paths = sophios.cli.get_dicts_for_compilation()
+    if lang_version is not None:
+        options['lang_version'] = lang_version
+    graph = GraphReps(graphviz.Digraph(name='cluster_v'), nx.DiGraph(), GraphData('v'))
+    info = sophios.compiler.compile_workflow(YamlTree(StepId('lang_version', 'global'), yml),
+                                             options, graph_settings, tag_paths,
+                                             [], [graph], {}, {}, {}, {},
+                                             tools_cwl, True, relative_run_path=True, testing=True)
+    compiled: Yaml = info.rose.data.compiled_cwl
+    return compiled
+
+
+TOUCH: Yaml = {'steps': [{'id': 'touch', 'in': {'filename': {'wic_inline_input': 'empty.txt'}}}]}
+
+
+# --------------------------------------------------------------------------
+# P15 / P16 / P17 — the resolution rule, over fabricated histories
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@given(histories)
+@FAST
+def test_p15_untagged_resolves_to_the_newest(known: tuple[str, ...]) -> None:
+    """P15: with nothing to satisfy, the highest known version is chosen."""
+    assert resolve_lang_version(None, (), known=known) == known[-1]
+
+
+@pytest.mark.fast
+@given(histories, st.data())
+@FAST
+def test_p16_no_lower_version_is_silently_selected(known: tuple[str, ...], data: st.DataObject) -> None:
+    """P16: a pin is the only thing that moves resolution below the newest,
+    and a pin is the author's word, not silence."""
+    pin = data.draw(st.sampled_from(known))
+    resolved = resolve_lang_version(None, (pin,), known=known)
+    assert resolved == pin
+    # Order is history position, not string order: '0.0.10' is newer than '0.0.2'.
+    untagged = resolve_lang_version(None, (), known=known)
+    assert known.index(untagged) >= known.index(resolved)
+
+
+@pytest.mark.fast
+@given(histories)
+@FAST
+def test_p17_untagged_never_fails(known: tuple[str, ...]) -> None:
+    """P17: resolution of an untagged tree cannot fail."""
+    resolve_lang_version(None, (), known=known)  # must not raise
+
+
+@pytest.mark.fast
+def test_unknown_versions_are_reported_not_coerced() -> None:
+    """Asking for a version that does not exist is an error naming the known
+    ones — never a silent fallback to something else."""
+    for request, pins in (('9.9.9', ()), (None, ('9.9.9',))):
+        with pytest.raises(SophiosError) as caught:
+            resolve_lang_version(request, pins)
+        assert caught.value.diagnostics[0].code is Code.UNKNOWN_LANG_VERSION
+        assert LANG_VERSION in caught.value.diagnostics[0].message
+
+
+# --------------------------------------------------------------------------
+# P20 / P21 — precedence and tree-wide oneness
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+@given(histories, st.data())
+@FAST
+def test_p20_explicit_beats_any_tag(known: tuple[str, ...], data: st.DataObject) -> None:
+    """P20: the explicit setting wins regardless of what the tree pins."""
+    explicit = data.draw(st.sampled_from(known))
+    pins = tuple(data.draw(st.lists(st.sampled_from(known), max_size=4)))
+    assert resolve_lang_version(explicit, pins, known=known) == explicit
+
+
+@pytest.mark.fast
+@given(histories, st.data())
+@FAST
+def test_p21_one_version_or_a_conflict_report(known: tuple[str, ...], data: st.DataObject) -> None:
+    """P21: agreeing pins resolve to their one version; disagreeing pins are
+    a reported conflict, never an average or a quiet winner."""
+    pins = tuple(data.draw(st.lists(st.sampled_from(known), min_size=1, max_size=4)))
+    if len(set(pins)) == 1:
+        assert resolve_lang_version(None, pins, known=known) == pins[0]
+    else:
+        with pytest.raises(SophiosError) as caught:
+            resolve_lang_version(None, pins, known=known)
+        assert caught.value.diagnostics[0].code is Code.LANG_VERSION_CONFLICT
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_p21_conflicting_pins_across_a_tree_are_caught_at_the_root() -> None:
+    """P21, integrated: a subworkflow pin that disagrees with the root's is a
+    conflict at compile time — the walk sees the whole merged tree."""
+    tree: Yaml = {
+        'wic': {'lang_version': '0.0.1'},
+        'steps': [{'id': 'touch',
+                   'in': {'filename': {'wic_inline_input': 'empty.txt'}},
+                   'wic': {'lang_version': '9.9.9'}}],
+    }
+    with pytest.raises(SophiosError) as caught:
+        _compile(tree)
+    assert caught.value.diagnostics[0].code is Code.UNKNOWN_LANG_VERSION
+
+
+# --------------------------------------------------------------------------
+# P18 / P19 — surfacing
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_p18_every_compile_reports_its_version() -> None:
+    """P18: the emitted artifact carries the resolved version, and so does the
+    tagged and the explicitly-pinned compile."""
+    assert _compile(TOUCH)[ANNOTATION_KEY] == LANG_VERSION
+    assert _compile({'wic': {'lang_version': '0.0.1'}, **TOUCH})[ANNOTATION_KEY] == '0.0.1'
+    assert _compile(TOUCH, lang_version='0.0.1')[ANNOTATION_KEY] == '0.0.1'
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_p18_the_python_api_surfaces_the_version() -> None:
+    """P18: `CompiledWorkflow.lang_version` names the version, no digging."""
+    from sophios.api.python.tool_builder import CommandLineTool, Input, Inputs, Output, Outputs, cwl
+    from sophios.api.python.workflow import Step, Workflow
+
+    emit = (CommandLineTool('emit_text',
+                            Inputs(message=Input(cwl.string, position=1)),
+                            Outputs(file=Output(cwl.file, glob='stdout.txt')))
+            .base_command('echo')
+            .stdout('stdout.txt'))
+    step = Step(emit)
+    step.inputs.message = 'hello'
+    compiled = Workflow([step], 'p18_version').compile()
+    assert compiled.lang_version == LANG_VERSION
+    assert compiled.cwl_workflow[ANNOTATION_KEY] == LANG_VERSION
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.slow
+def test_p19_annotation_is_declared_and_the_cwl_stays_valid() -> None:
+    """P19: the annotation is a namespaced extension field, its namespace is
+    declared, and cwltool still accepts the artifact as CWL v1.2."""
+    import cwltool.main  # pylint: disable=import-outside-toplevel  # expensive; slow lane only
+
+    options, graph_settings, tag_paths = sophios.cli.get_dicts_for_compilation()
+    graph = GraphReps(graphviz.Digraph(name='cluster_v'), nx.DiGraph(), GraphData('v'))
+    info = sophios.compiler.compile_workflow(YamlTree(StepId('lang_version', 'global'), TOUCH),
+                                             options, graph_settings, tag_paths,
+                                             [], [graph], {}, {}, {}, {},
+                                             tools_cwl, True, relative_run_path=True, testing=True)
+    inlined = sophios.post_compile.cwl_inline_runtag(info.rose).data.compiled_cwl
+
+    assert inlined[ANNOTATION_KEY] == LANG_VERSION
+    assert inlined['$namespaces'][ANNOTATION_NAMESPACE] == ANNOTATION_NAMESPACE_URI
+
+    target = Path('autogenerated') / 'p19_annotated.cwl'
+    target.parent.mkdir(exist_ok=True)
+    target.write_text(yaml.safe_dump(inlined, sort_keys=False), encoding='utf-8')
+    assert cwltool.main.main(['--validate', '--quiet', str(target)]) == 0
+
+
+# --------------------------------------------------------------------------
+# Sanity
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.fast
+def test_exactly_one_version_exists_today() -> None:
+    """When this fails, versions.py has grown a second entry — go make sure
+    the resolution table in the reference (§7) still tells the truth."""
+    assert KNOWN_VERSIONS == ('0.0.1',)
+    assert LANG_VERSION == '0.0.1'

--- a/tests/core/test_leak_boundary.py
+++ b/tests/core/test_leak_boundary.py
@@ -236,3 +236,31 @@ def test_p13_residue_validates_as_cwl_v1_2(freight: dict[str, Any]) -> None:
 
     assert cwltool.main.main(['--validate', '--quiet', str(target)]) == 0
     assert inlined['cwlVersion'] == 'v1.2'
+
+# --------------------------------------------------------------------------
+# P08 — the --allow_raw_cwl escape hatch still works
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.skip_pypi_ci
+@pytest.mark.fast
+def test_p08_allow_raw_cwl_is_the_difference_between_report_and_compile() -> None:
+    """P08: a bare unresolved name is reported without the flag and compiles
+    with it — the flag's one-line definition, observed at the boundary."""
+    from sophios.lang.diagnostics import Code, SophiosError
+
+    bare: Yaml = {'steps': [{'id': 'touch', 'in': {'filename': 'not_a_workflow_input'}}]}
+
+    with pytest.raises(SophiosError) as caught:
+        _compile(bare)
+    assert caught.value.diagnostics[0].code is Code.UNRESOLVED_INPUT
+    assert '!ii' in caught.value.diagnostics[0].message
+
+    options, graph_settings, tag_paths = sophios.cli.get_dicts_for_compilation()
+    options = {**options, 'allow_raw_cwl': True}
+    graph = GraphReps(graphviz.Digraph(name='cluster_p08'), nx.DiGraph(), GraphData('p08'))
+    info = sophios.compiler.compile_workflow(YamlTree(StepId('p08', 'global'), bare),
+                                             options, graph_settings, tag_paths,
+                                             [], [graph], {}, {}, {}, {},
+                                             tools_cwl, True, relative_run_path=True, testing=True)
+    assert info.rose.data.compiled_cwl['class'] == 'Workflow'


### PR DESCRIPTION
Stacks on #7 (`semrefac_6`); the two commits after its tip are this PR, and Spec 1 closes with it.

`lang_version` goes from a documented intention to a resolved fact. `lang/versions.py` owns what versions exist and how one is chosen: an explicit setting wins, per-file `wic: lang_version:` tags are exact pins, and an untagged tree gets the newest version — never silently anything lower. Conflicting pins are reported, unknown versions are reported naming the known ones, and neither is ever coerced. Exactly one version exists today, so production resolution always lands on 0.0.1; the mechanism is still written and property-tested for the general case, over fabricated version histories, because the first real version bump is precisely when nobody will want to discover the resolver was a stub that worked by coincidence. Resolution happens once at the root over every tag in the merged tree, and subworkflow compilations inherit the result as an explicit setting through a copied options dict — one compilation, one version, tree-wide, with no shared-state mutation.

Inference is invisible by construction, so visibility is a hard requirement rather than a courtesy: the resolved version is printed by the CLI on every compile, carried as `CompiledWorkflow.lang_version` on the Python API, and annotated in the emitted CWL as `sophios:lang_version` — a declared extension field, so `cwltool` still accepts the artifact, which is checked by running `cwltool`. The `--lang_version` flag and `Workflow.compile(lang_version=...)` set the version explicitly and beat any file tag. Like `edam` before it, the `sophios` namespace prefix is now reserved in emitted `$namespaces`, and the reference documents both under the same note.
